### PR TITLE
Fix locales for rails 2.3.9

### DIFF
--- a/lib/inherited_resources/locales/en.yml
+++ b/lib/inherited_resources/locales/en.yml
@@ -2,9 +2,9 @@ en:
   flash:
     actions:
       create:
-        notice: '{{resource_name}} was successfully created.'
+        notice: '%{resource_name} was successfully created.'
       update:
-        notice: '{{resource_name}} was successfully updated.'
+        notice: '%{resource_name} was successfully updated.'
       destroy:
-        notice: '{{resource_name}} was successfully destroyed.'
-        alert: '{{resource_name}} could not be destroyed.'
+        notice: '%{resource_name} was successfully destroyed.'
+        alert: '%{resource_name} could not be destroyed.'


### PR DESCRIPTION
The i18n stuff has changed for rails 2.3.9, it's using the new %{} syntax over the {{}} syntax like before.  This fixes the default en.yml to reflect that.
