### PR TITLE
Better support for namespaced controllers

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -463,6 +463,20 @@ option.
 
 It will deal with everything again and hide the action :index from you.
 
+== Namespaced Controllers
+
+Namespaced controllers works out the box.
+
+    class Forum::PostsController < InheritedResources::Base
+    end
+
+Inherited Resources prioritizes the default resource class for the namespaced controller in
+this order:
+
+    Forum::Post
+    ForumPost
+    Post
+
 == URL Helpers
 
 When you use InheritedResources it creates some URL helpers.

--- a/lib/inherited_resources/actions.rb
+++ b/lib/inherited_resources/actions.rb
@@ -42,7 +42,7 @@ module InheritedResources
     def update(options={}, &block)
       object = resource
 
-      if update_resource(object, params[resource_instance_name])
+      if update_resource(object, params[resource_request_name])
         options[:location] ||= redirect_to_url
       end
 

--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -46,7 +46,7 @@ module InheritedResources
       # instance variable.
       #
       def build_resource
-        get_resource_ivar || set_resource_ivar(end_of_association_chain.send(method_for_build, params[resource_instance_name] || {}))
+        get_resource_ivar || set_resource_ivar(end_of_association_chain.send(method_for_build, params[resource_request_name] || {}))
       end
 
       # Responsible for saving the resource on :create method. Overwriting this
@@ -153,6 +153,10 @@ module InheritedResources
       #
       def resource_instance_name #:nodoc:
         self.resources_configuration[:self][:instance_name]
+      end
+
+      def resource_request_name
+        self.resources_configuration[:self][:request_name]
       end
 
       # This methods gets your begin_of_association_chain, join it with your

--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -255,7 +255,21 @@ module InheritedResources
       #
       def initialize_resources_class_accessors! #:nodoc:
         # Initialize resource class
+
+        # First priority is the namespaced modek, e.g. User::Group
         self.resource_class = begin
+          namespaced_class = self.name.sub(/Controller/, '').singularize
+          namespaced_class.constantize
+        rescue NameError; nil end
+
+        # Second priority the camelcased c, i.e. UserGroup
+        self.resource_class ||= begin
+          camelcased_class = self.name.sub(/Controller/, '').gsub('::', '').singularize
+          camelcased_class.constantize
+        rescue NameError; nil end
+
+        # Otherwise use the Group class, or fail
+        self.resource_class ||= begin
           class_name = self.controller_name.classify
           class_name.constantize
         rescue NameError => e

--- a/test/defaults_test.rb
+++ b/test/defaults_test.rb
@@ -140,3 +140,37 @@ class DefaultsNamespaceTest < ActionController::TestCase
     end
 end
 
+class Group
+end
+class AdminGroup
+end
+module Admin; end
+class Admin::Group
+end
+class Admin::GroupsController < InheritedResources::Base
+end
+class NamespacedModelForNamespacedController < ActionController::TestCase
+  tests Admin::GroupsController
+
+  def test_that_it_picked_the_namespaced_model
+    # make public so we can test it
+    Admin::GroupsController.send(:public, *Admin::GroupsController.protected_instance_methods)
+    assert_equal Admin::Group, @controller.resource_class
+  end
+end
+
+class Role
+end
+class AdminRole
+end
+class Admin::RolesController < InheritedResources::Base
+end
+class TwoPartNameModelForNamespacedController < ActionController::TestCase
+  tests Admin::RolesController
+
+  def test_that_it_picked_the_camelcased_model
+    # make public so we can test it
+    Admin::RolesController.send(:public, *Admin::RolesController.protected_instance_methods)
+    assert_equal AdminRole, @controller.resource_class
+  end
+end

--- a/test/defaults_test.rb
+++ b/test/defaults_test.rb
@@ -73,3 +73,70 @@ class DefaultsTest < ActionController::TestCase
     end
 end
 
+class Professor
+  def self.human_name; 'Einstein'; end
+end
+module University; end
+class University::ProfessorsController < InheritedResources::Base
+  defaults :finder => :find_by_slug
+end
+
+class DefaultsNamespaceTest < ActionController::TestCase
+  tests University::ProfessorsController
+
+  def setup
+    @controller.stubs(:resource_url).returns('/')
+    @controller.stubs(:collection_url).returns('/')
+  end
+
+  def test_expose_all_professors_as_instance_variable
+    Professor.expects(:all).returns([mock_professor])
+    get :index
+    assert_equal [mock_professor], assigns(:professors)
+  end
+
+  def test_expose_the_requested_painter_on_show
+    Professor.expects(:find_by_slug).with('forty_two').returns(mock_professor)
+    get :show, :id => 'forty_two'
+    assert_equal mock_professor, assigns(:professor)
+  end
+
+  def test_expose_a_new_painter
+    Professor.expects(:new).returns(mock_professor)
+    get :new
+    assert_equal mock_professor, assigns(:professor)
+  end
+
+  def test_expose_the_requested_painter_on_edit
+    Professor.expects(:find_by_slug).with('forty_two').returns(mock_professor)
+    get :edit, :id => 'forty_two'
+    assert_response :success
+    assert_equal mock_professor, assigns(:professor)
+  end
+
+  def test_expose_a_newly_create_professor_when_saved_with_success
+    Professor.expects(:new).with({'these' => 'params'}).returns(mock_professor(:save => true))
+    post :create, :university_professor => {:these => 'params'}
+    assert_equal mock_professor, assigns(:professor)
+  end
+
+  def test_update_the_professor
+    Professor.expects(:find_by_slug).with('forty_two').returns(mock_professor)
+    mock_professor.expects(:update_attributes).with({'these' => 'params'}).returns(true)
+    put :update, :id => 'forty_two', :university_professor => {:these => 'params'}
+    assert_equal mock_professor, assigns(:professor)
+  end
+
+  def test_the_requested_painter_is_destroyed
+    Professor.expects(:find_by_slug).with('forty_two').returns(mock_professor)
+    mock_professor.expects(:destroy)
+    delete :destroy, :id => 'forty_two'
+    assert_equal mock_professor, assigns(:professor)
+  end
+
+  protected
+    def mock_professor(stubs={})
+      @mock_professor ||= mock(stubs)
+    end
+end
+

--- a/test/views/university/professors/edit.html.erb
+++ b/test/views/university/professors/edit.html.erb
@@ -1,0 +1,1 @@
+Edit HTML

--- a/test/views/university/professors/index.html.erb
+++ b/test/views/university/professors/index.html.erb
@@ -1,0 +1,1 @@
+Index HTML

--- a/test/views/university/professors/new.html.erb
+++ b/test/views/university/professors/new.html.erb
@@ -1,0 +1,1 @@
+New HTML

--- a/test/views/university/professors/show.html.erb
+++ b/test/views/university/professors/show.html.erb
@@ -1,0 +1,1 @@
+Show HTML


### PR DESCRIPTION
I had trouble with namespaced controllers not picking up the request params. I achieved the wished behavior by changing the instance name, however to me it seems odd that the request params fetching relies on something freely changeable by the user. In my patch the request params are extracted directly from the controller name, now users can change the instance name as they like without breaking Inherited Resources.

Furthermore, I included a model prioritizing system for namespaced controllers. If you have a namespaced Forum posts controller like this:

```
class Forum::PostsController < InheritedResources::Base
end
```

Inherited Resources with this patch prioritizes the resource class for the namespaced controller in
this order:

```
Forum::Post 
ForumPost   
Post
```

In lieu of going directly for the User model as current `master` does.

This should close issues like these:
https://github.com/josevalim/inherited_resources/issues/issue/64
Should now work as the issue author described, out the box.

https://github.com/josevalim/inherited_resources/issues#issue/109
Instance name issue
