### PR TITLE
Fix for refreshing ApplicationHelper in development mode

### DIFF
--- a/lib/inherited_resources/base.rb
+++ b/lib/inherited_resources/base.rb
@@ -39,6 +39,11 @@ module InheritedResources
           :resource_class?, :parents_symbols?, :resources_configuration?
       end
     end
+    
+    def self.inherited(klass)
+      super
+      klass.helper :all if klass.superclass == InheritedResources::Base
+    end
 
     inherit_resources(self)
   end


### PR DESCRIPTION
This is a fix for issue #95.
It essentially overwrites this method from ActionController::Base

```
def self.inherited(klass)
  super
  klass.helper :all if klass.superclass == ActionController::Base
end
```

I'm not sure if this is the most elegant fix, but it does work for me.

Best regards,
Fabian
