### PR TITLE
:param for :finder to base on

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -41,13 +41,6 @@ module InheritedResources
         get_resource_ivar || set_resource_ivar(end_of_association_chain.send(method_for_find, params[param_name_for_find]))
       end
       
-      # Supplies finder with param name to search with.
-      # You can easily override your finder with overriding this method
-      # and #method_for_find
-      def param_name_for_find
-        :id
-      end
-      
       # This method is responsable for building the object on :new and :create
       # methods. If you overwrite it, don't forget to cache the result in an
       # instance variable.
@@ -209,6 +202,11 @@ module InheritedResources
       # Returns finder method for instantiate resource by params[:id]
       def method_for_find
         resources_configuration[:self][:finder] || :find
+      end
+      
+      # Supplies finder with param name to search with.
+      def param_name_for_find
+        resources_configuration[:self][:param] || :id
       end
 
       # Get resource ivar based on the current resource controller.

--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -38,9 +38,16 @@ module InheritedResources
       # probably render a 500 error message.
       #
       def resource
-        get_resource_ivar || set_resource_ivar(end_of_association_chain.send(method_for_find, params[:id]))
+        get_resource_ivar || set_resource_ivar(end_of_association_chain.send(method_for_find, params[param_name_for_find]))
       end
-
+      
+      # Supplies finder with param name to search with.
+      # You can easily override your finder with overriding this method
+      # and #method_for_find
+      def param_name_for_find
+        :id
+      end
+      
       # This method is responsable for building the object on :new and :create
       # methods. If you overwrite it, don't forget to cache the result in an
       # instance variable.

--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -38,7 +38,7 @@ module InheritedResources
       # probably render a 500 error message.
       #
       def resource
-        get_resource_ivar || set_resource_ivar(end_of_association_chain.send(method_for_find, params[param_name_for_find]))
+        get_resource_ivar || set_resource_ivar(end_of_association_chain.send(method_for_find, params[param_name_for_finder]))
       end
       
       # This method is responsable for building the object on :new and :create
@@ -205,7 +205,7 @@ module InheritedResources
       end
       
       # Supplies finder with param name to search with.
-      def param_name_for_find
+      def param_name_for_finder
         resources_configuration[:self][:param] || :id
       end
 

--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -40,7 +40,7 @@ module InheritedResources
         options.symbolize_keys!
         options.assert_valid_keys(:resource_class, :collection_name, :instance_name,
                                   :class_name, :route_prefix, :route_collection_name,
-                                  :route_instance_name, :singleton, :finder)
+                                  :route_instance_name, :singleton, :finder, :param)
 
         self.resource_class = options[:resource_class] if options.key?(:resource_class)
         self.resource_class = options[:class_name].constantize if options.key?(:class_name)


### PR DESCRIPTION
I've needed to find a model with `find_by_name` param, but it was still searching by `params[:id]`, so I patched in the `resource` method to use param from new function `param_name_for_finder`. It can be used like this:

`defaults :finder => :find_by_name, :param => :object_name`
