### PR TITLE
Scoped collection

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -20,7 +20,10 @@ module InheritedResources
       #   end
       #
       def collection
-        get_collection_ivar || set_collection_ivar(end_of_association_chain.scoped)
+        get_collection_ivar || begin
+          c = end_of_association_chain
+          set_collection_ivar(c.respond_to?(:scoped) ? c.scoped : c.all)
+        end
       end
 
       # This is how the resource is loaded.

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -76,6 +76,12 @@ class IndexActionBaseTest < ActionController::TestCase
     assert_response :success
     assert_equal 'Generated XML', @response.body
   end
+
+  def test_scoped_is_called_only_when_available
+    User.stubs(:all).returns([mock_user])
+    get :index
+    assert_equal Array, assigns(:users).class
+  end
 end
 
 class ShowActionBaseTest < ActionController::TestCase


### PR DESCRIPTION
User brodock has reported that my last patch doesn't work with ActiveResource which does not implement `scoped`. This commit makes us use `scoped` only when `end_of_association_chain` responds to it and `all` otherwise.
