### PR TITLE
This pull request adds ability to get params[config[:resource_name]]  instead of params[config[:request_name]]

### DIFF
--- a/lib/inherited_resources/actions.rb
+++ b/lib/inherited_resources/actions.rb
@@ -42,7 +42,7 @@ module InheritedResources
     def update(options={}, &block)
       object = resource
 
-      if update_resource(object, params[resource_request_name] || params[resource_instance_name])
+      if update_resource(object, resource_params)
         options[:location] ||= smart_resource_url
       end
 

--- a/lib/inherited_resources/actions.rb
+++ b/lib/inherited_resources/actions.rb
@@ -42,7 +42,7 @@ module InheritedResources
     def update(options={}, &block)
       object = resource
 
-      if update_resource(object, params[resource_request_name])
+      if update_resource(object, params[resource_request_name] || params[resource_instance_name])
         options[:location] ||= smart_resource_url
       end
 

--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -49,7 +49,7 @@ module InheritedResources
       # instance variable.
       #
       def build_resource
-        get_resource_ivar || set_resource_ivar(end_of_association_chain.send(method_for_build, params[resource_request_name] || params[resource_instance_name] || {}))
+        get_resource_ivar || set_resource_ivar(end_of_association_chain.send(method_for_build, resource_params))
       end
 
       # Responsible for saving the resource on :create method. Overwriting this
@@ -296,6 +296,11 @@ module InheritedResources
           url ||= parent_url rescue nil
         end
         url ||= root_url rescue nil
+      end
+
+      # extract attributes from params
+      def resource_params
+        params[resource_request_name] || params[resource_instance_name] || {}
       end
   end
 end

--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -46,7 +46,7 @@ module InheritedResources
       # instance variable.
       #
       def build_resource
-        get_resource_ivar || set_resource_ivar(end_of_association_chain.send(method_for_build, params[resource_request_name] || {}))
+        get_resource_ivar || set_resource_ivar(end_of_association_chain.send(method_for_build, params[resource_request_name] || params[resource_instance_name] || {}))
       end
 
       # Responsible for saving the resource on :create method. Overwriting this

--- a/test/nested_model_with_shallow_test.rb
+++ b/test/nested_model_with_shallow_test.rb
@@ -57,6 +57,20 @@ class NestedModelWithShallowTest < ActionController::TestCase
     assert_equal mock_group, assigns(:group)
   end
 
+  def test_expose_a_newly_create_group_with_speciality
+    Speciality.expects(:find).with('37').twice.returns(mock_speciality)
+    Plan::Group.expects(:build).with({'these' => :params}).returns(mock_group(:save => true))
+    post :create, :speciality_id => '37', :group => {:these => :params}
+    assert_equal mock_group, assigns(:group)
+  end
+
+  def test_expose_a_update_group_with_speciality
+    should_find_parents
+    mock_group.expects(:update_attributes).with('these' => :params).returns(true)
+    post :update, :id => 'forty_two', :group => {:these => :params}
+    assert_equal mock_group, assigns(:group)
+  end
+
   protected
     def should_find_parents
       Plan::Group.expects(:find_by_slug).with('forty_two').returns(mock_group)


### PR DESCRIPTION
```
class My::Model

class SomeController
  defaults :resource_name => :model
end
```

now works as earlier (it was broken after Sirupsens patches)
