### PR TITLE
Added support for rails 3.1 new mass assignment conventions

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -49,7 +49,7 @@ module InheritedResources
       # instance variable.
       #
       def build_resource
-        get_resource_ivar || set_resource_ivar(end_of_association_chain.send(method_for_build, resource_params))
+        get_resource_ivar || set_resource_ivar(end_of_association_chain.send(method_for_build, *resource_params))
       end
 
       # Responsible for saving the resource on :create method. Overwriting this
@@ -75,7 +75,7 @@ module InheritedResources
       #   end
       #
       def update_resource(object, attributes)
-        object.update_attributes(attributes)
+        object.update_attributes(*attributes)
       end
 
       # Handle the :destroy method for the resource. Overwrite it to call your
@@ -300,7 +300,19 @@ module InheritedResources
 
       # extract attributes from params
       def resource_params
-        params[resource_request_name] || params[resource_instance_name] || {}
+        rparams = [params[resource_request_name] || params[resource_instance_name] || {}]
+        rparams << as_role if role_given?
+        rparams
+      end
+      
+      # checking if role given
+      def role_given?
+        self.resources_configuration[:self][:role].present?
+      end
+      
+      # getting role for mass-asignment
+      def as_role
+         { :as => self.resources_configuration[:self][:role] }
       end
   end
 end

--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -255,6 +255,12 @@ module InheritedResources
         end
       end
 
+      # Defines the role to use when creating or updating resource.
+      # Makes sense when using rails 3.1 mass assignment conventions
+      def with_role(role)
+        self.resources_configuration[:self][:role] = role.try(:to_sym)
+      end 
+
     private
 
       def acts_as_singleton! #:nodoc:

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -178,6 +178,14 @@ class CreateActionBaseTest < ActionController::TestCase
     post :create, :user => {:these => 'params'}
     assert_equal mock_user, assigns(:user)
   end
+  
+  def test_expose_a_newly_create_user_when_saved_with_success_and_role_setted
+    @controller.class.send(:with_role, :admin)
+    User.expects(:new).with({'these' => 'params'}, {:as => :admin}).returns(mock_user(:save => true))
+    post :create, :user => {:these => 'params'}
+    assert_equal mock_user, assigns(:user)
+    @controller.class.send(:with_role, nil)
+  end
 
   def test_redirect_to_the_created_user
     User.stubs(:new).returns(mock_user(:save => true))
@@ -220,6 +228,15 @@ class UpdateActionBaseTest < ActionController::TestCase
     mock_user.expects(:update_attributes).with({'these' => 'params'}).returns(true)
     put :update, :id => '42', :user => {:these => 'params'}
     assert_equal mock_user, assigns(:user)
+  end
+  
+  def test_update_the_requested_object_when_setted_role
+    @controller.class.send(:with_role, :admin)
+    User.expects(:find).with('42').returns(mock_user)
+    mock_user.expects(:update_attributes).with({'these' => 'params'}, {:as => :admin}).returns(true)
+    put :update, :id => '42', :user => {:these => 'params'}
+    assert_equal mock_user, assigns(:user)
+    @controller.class.send(:with_role, nil)
   end
 
   def test_redirect_to_the_updated_user

--- a/test/customized_base_test.rb
+++ b/test/customized_base_test.rb
@@ -26,7 +26,7 @@ class CarsController < InheritedResources::Base
     end
 
     def update_resource(resource, attributes)
-      resource.update_successfully(attributes)
+      resource.update_successfully(*attributes)
     end
 
     def destroy_resource(resource)


### PR DESCRIPTION
I've added new method 'with_role' that can be used to set the role that will be used for 'new' and 'update_attrbutes' methods to satisfy new rails 3.1 mass assignment conventions
