### PR TITLE
Allow to set roles dynamically

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -312,7 +312,9 @@ module InheritedResources
       
       # getting role for mass-asignment
       def as_role
-         { :as => self.resources_configuration[:self][:role] }
+        role = self.resources_configuration[:self][:role]
+        role = role.call(self) if role.respond_to?(:call)
+        { :as => role.try(:to_sym) }
       end
   end
 end

--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -258,8 +258,8 @@ module InheritedResources
       # Defines the role to use when creating or updating resource.
       # Makes sense when using rails 3.1 mass assignment conventions
       def with_role(role)
-        self.resources_configuration[:self][:role] = role.try(:to_sym)
-      end 
+        self.resources_configuration[:self][:role] = role
+      end
 
     private
 

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -187,6 +187,14 @@ class CreateActionBaseTest < ActionController::TestCase
     @controller.class.send(:with_role, nil)
   end
 
+  def test_expose_a_newly_create_user_when_saved_with_success_and_dynamic_role_setted
+    @controller.class.send(:with_role, lambda {|c| c.params[:user][:these] == 'params' ? :admin : nil})
+    User.expects(:new).with({'these' => 'params'}, {:as => :admin}).returns(mock_user(:save => true))
+    post :create, :user => {:these => 'params'}
+    assert_equal mock_user, assigns(:user)
+    @controller.class.send(:with_role, nil)
+  end
+
   def test_redirect_to_the_created_user
     User.stubs(:new).returns(mock_user(:save => true))
     @controller.expects(:resource_url).returns('http://test.host/')
@@ -232,6 +240,15 @@ class UpdateActionBaseTest < ActionController::TestCase
   
   def test_update_the_requested_object_when_setted_role
     @controller.class.send(:with_role, :admin)
+    User.expects(:find).with('42').returns(mock_user)
+    mock_user.expects(:update_attributes).with({'these' => 'params'}, {:as => :admin}).returns(true)
+    put :update, :id => '42', :user => {:these => 'params'}
+    assert_equal mock_user, assigns(:user)
+    @controller.class.send(:with_role, nil)
+  end
+
+  def test_update_the_requested_object_when_setted_role_dynamically
+    @controller.class.send(:with_role, lambda {|c| c.params[:user][:these] == 'params' ? :admin : nil})
     User.expects(:find).with('42').returns(mock_user)
     mock_user.expects(:update_attributes).with({'these' => 'params'}, {:as => :admin}).returns(true)
     put :update, :id => '42', :user => {:these => 'params'}


### PR DESCRIPTION
Now you can set with_role based on current user. Like this:

  with_role lambda{|c| c.current_user.try(:role)}
  with_role lambda{|c| c.current_user.try(:admin?) ? 'admin' : nil}
