### PR TITLE
can't get the parent in a polymorphic_belongs_to 

### DIFF
--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -181,6 +181,7 @@ module InheritedResources
             nil
           end
 
+
           config[:collection_name] = options.delete(:collection_name) || symbol.to_s.pluralize.to_sym
           config[:instance_name]   = options.delete(:instance_name) || symbol
           config[:param]           = options.delete(:param) || :"#{symbol}_id"

--- a/lib/inherited_resources/polymorphic_helpers.rb
+++ b/lib/inherited_resources/polymorphic_helpers.rb
@@ -90,25 +90,32 @@ module InheritedResources
       # as parent types.
       #
       def parent_type
+        unless @parent_type
+          symbols_for_association_chain
+        end
+
         @parent_type
       end
 
       def parent_class
-        parent.class if @parent_type
+        parent.class if parent_type
       end
 
       # Returns the parent object. They are also available with the instance
       # variable name: @task, @file, @note...
       #
       def parent
-        instance_variable_get("@#{@parent_type}") if @parent_type
+        if parent_type
+          p = instance_variable_get("@#{parent_type}")
+          p || instance_variable_set("@#{parent_type}", association_chain[-1])
+        end
       end
 
       # If the polymorphic association is optional, we might not have a parent.
       #
       def parent?
         if resources_configuration[:polymorphic][:optional]
-          parents_symbols.size > 1 || !@parent_type.nil?
+          parents_symbols.size > 1 || !parent_type.nil?
         else
           true
         end

--- a/test/polymorphic_test.rb
+++ b/test/polymorphic_test.rb
@@ -2,6 +2,8 @@ require File.expand_path('test_helper', File.dirname(__FILE__))
 
 class Factory; end
 class Company; end
+class User; end
+class Photo; end
 
 class Employee
   def self.human_name; 'Employee'; end
@@ -9,6 +11,15 @@ end
 
 class EmployeesController < InheritedResources::Base
   belongs_to :factory, :company, :polymorphic => true
+end
+
+class PhotosController < InheritedResources::Base
+  belongs_to :user, :task, :polymorphic => true
+
+  def index
+    parent
+    # Overwrite index
+  end
 end
 
 class PolymorphicFactoriesTest < ActionController::TestCase
@@ -182,5 +193,23 @@ class PolymorphicCompanyTest < ActionController::TestCase
 
     def mock_employee(stubs={})
       @mock_employee ||= mock(stubs)
+    end
+end
+
+class PolymorphicPhotosTest < ActionController::TestCase
+  tests PhotosController
+
+  def setup
+    User.expects(:find).with('37').returns(mock_user)
+  end
+
+  def test_parent_as_instance_variable_on_index_when_method_overwritten
+    get :index, :user_id => '37'
+    assert_equal mock_user, assigns(:user)
+  end
+
+  protected
+    def mock_user(stubs={})
+      @mock_user ||= mock(stubs)
     end
 end

--- a/test/url_helpers_test.rb
+++ b/test/url_helpers_test.rb
@@ -665,7 +665,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     new_bed.stubs(:persisted?).returns(false)
 
     controller = BedsController.new
-    controller.instance_variable_set('@parent_type', nil)
+    controller.stubs(:parent_type).returns(nil)
     controller.instance_variable_set('@bed', bed)
 
     [:url, :path].each do |path_or_url|

--- a/test/views/photos/index.html.erb
+++ b/test/views/photos/index.html.erb
@@ -1,0 +1,1 @@
+Index HTML


### PR DESCRIPTION
I can't access the parent object when I use a polymorphic relation between my controllers.

Following the documentation, I have a controller like this:

``` ruby
class PhotosController < InheritedResources::Base
  belongs_to :user, :task, :polymorphic => true

  def index
    logger.debug(parent.inspect)
  end
end
```

But parent always returns nil. It doesn't work either with:

``` ruby
polymorphic_belongs_to :user, :task 
```

However, it works if I don't use a polymorphic relation:

``` ruby
belongs_to :user 
```

or

``` ruby
belongs_to :task 
```

Note that my routes and everything else regarding inherited_resources work fine.

I don't know if it is a bug, or if I misinterpreted  the documentation.

thanks for your help

julien
