### PR TITLE
Fix url helpers on mountable engines

### DIFF
--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -338,6 +338,16 @@ module InheritedResources
 
         # Deal with namespaced controllers
         namespaces = self.controller_path.split('/')[0..-2]
+
+        # Remove namespace if its a mountable engine
+        namespaces.delete_if do |namespace|
+          begin
+            "#{namespace}/engine".camelize.constantize.isolated?
+          rescue
+            false
+          end
+        end
+
         config[:route_prefix] = namespaces.join('_') unless namespaces.empty?
 
         # Deal with default request parameters in namespaced controllers, e.g.

--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -23,6 +23,18 @@ class DeansController < InheritedResources::Base
   belongs_to :school
 end
 
+module MyEngine
+  class Engine < Rails::Engine
+    isolate_namespace MyEngine
+  end
+
+  class PeopleController < InheritedResources::Base; end
+end
+
+module MyNamespace
+  class PeopleController < InheritedResources::Base; end
+end
+
 class ActionsClassMethodTest < ActionController::TestCase
   tests BooksController
 
@@ -130,5 +142,16 @@ class BelongsToErrorsTest < ActiveSupport::TestCase
     end
   ensure
     DeansController.send(:parents_symbols=, [:school])
+  end
+end
+
+class MountableEngineTest < ActiveSupport::TestCase
+  def test_route_prefix_do_not_include_engine_name
+    puts MyEngine::PeopleController.send(:resources_configuration)[:self][:route_prefix]
+    assert_nil MyEngine::PeopleController.send(:resources_configuration)[:self][:route_prefix]
+  end
+
+  def test_route_prefix_present_when_parent_module_is_not_a_engine
+    assert_equal 'my_namespace', MyNamespace::PeopleController.send(:resources_configuration)[:self][:route_prefix]
   end
 end


### PR DESCRIPTION
Original pull request: https://github.com/josevalim/inherited_resources/pull/186 by @marcelloma

Changed to trust on a public API instead a obscure method (**_railtie**) and verifies if the engine has an isolated namespace.
