### PR TITLE
failing test for custom actions with and without optional parents

### DIFF
--- a/test/url_helpers_test.rb
+++ b/test/url_helpers_test.rb
@@ -119,6 +119,14 @@ class ButtonsController < InheritedResources::Base
   custom_actions :resource => :delete, :collection => :search
 end
 
+class PanelController < InheritedResources::Base
+  belongs_to :display, :optional => true do
+    belongs_to :window
+  end
+  
+  custom_actions :resource => :lock, :collection => :search
+end
+
 class ImageButtonsController < ButtonsController
 end
 
@@ -761,6 +769,33 @@ class UrlHelpersTest < ActiveSupport::TestCase
       controller.send("delete_resource_#{path_or_url}")
 
       controller.expects("search_window_buttons_#{path_or_url}").with(:window, {}).once
+      controller.send("search_resources_#{path_or_url}")
+    end
+  end
+  
+  def test_url_helpers_on_custom_actions_with_optional_parents
+    controller = PanelController.new
+    controller.instance_variable_set('@display', :display)
+    controller.instance_variable_set('@window', :window)
+    controller.instance_variable_set('@panel', :panel)
+    [:url, :path].each do |path_or_url|
+      controller.expects("lock_display_window_panel_#{path_or_url}").with(:panel, {}).once
+      controller.send("lock_resource_#{path_or_url}")
+
+      controller.expects("search_display_window_panels_#{path_or_url}").with(:window, {}).once
+      controller.send("search_resources_#{path_or_url}")
+    end
+  end
+  
+  def test_url_helpers_on_custom_actions_without_optional_parents
+    controller = PanelController.new
+    controller.instance_variable_set('@window', :window)
+    controller.instance_variable_set('@panel', :panel)
+    [:url, :path].each do |path_or_url|
+      controller.expects("lock_window_panel_#{path_or_url}").with(:panel, {}).once
+      controller.send("lock_resource_#{path_or_url}")
+
+      controller.expects("search_window_panels_#{path_or_url}").with(:window, {}).once
       controller.send("search_resources_#{path_or_url}")
     end
   end


### PR DESCRIPTION
I tried creating a patch but was unsuccessful. Could you please look at these failing tests to see if you have an idea for a workarount.  The problem roots from custom actions not having a polymorphic path. The workaround in [this post](http://stackoverflow.com/questions/6142013/polymorphic-path-for-custom-collection-route) worked for me on an individual basis.  Instead of using the custom action url helpers `archive_resource_url` I am using the main helper with a :action option `resource_url(:action => :archive)`
