### PR TITLE
Add missing space to `symbols_for_association_chain` keys empty error

### DIFF
--- a/lib/inherited_resources/polymorphic_helpers.rb
+++ b/lib/inherited_resources/polymorphic_helpers.rb
@@ -142,7 +142,7 @@ module InheritedResources
             end.compact
 
             if keys.empty?
-              raise ScriptError, "Could not find param for polymorphic association. The request" <<
+              raise ScriptError, "Could not find param for polymorphic association. The request " <<
                                  "parameters are #{params.keys.inspect} and the polymorphic " <<
                                  "associations are #{polymorphic_config[:symbols].inspect}." unless polymorphic_config[:optional]
 


### PR DESCRIPTION
Tiny error, thought I may as well fix it since I saw it though.

:-)
