### PR TITLE
Added :router to defaults

### DIFF
--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -28,6 +28,8 @@ module InheritedResources
       # * <tt>:route_prefix</tt> - The route prefix which is automically set in namespaced
       #                            controllers. Default to :admin on Admin::ProjectsController.
       #
+      # * <tt>:router</tt> - The router which is automatically used in isolated engines.
+      #
       # * <tt>:singleton</tt> - Tells if this controller is singleton or not.
       #
       # * <tt>:finder</tt> - Specifies which method should be called to instantiate the resource.
@@ -39,7 +41,7 @@ module InheritedResources
 
         options.symbolize_keys!
         options.assert_valid_keys(:resource_class, :collection_name, :instance_name,
-                                  :class_name, :route_prefix, :route_collection_name,
+                                  :class_name, :route_prefix, :router, :route_collection_name,
                                   :route_instance_name, :singleton, :finder)
 
         self.resource_class = options[:resource_class] if options.key?(:resource_class)
@@ -49,6 +51,7 @@ module InheritedResources
 
         config = self.resources_configuration[:self]
         config[:route_prefix] = options.delete(:route_prefix) if options.key?(:route_prefix)
+        config[:router] = options.delete(:router) if options.key?(:router)
 
         if options.key?(:resource_class) or options.key?(:class_name)
           config[:request_name] = self.resource_class.to_s.underscore.gsub('/', '_')

--- a/lib/inherited_resources/url_helpers.rb
+++ b/lib/inherited_resources/url_helpers.rb
@@ -46,6 +46,7 @@ module InheritedResources
     def create_resources_url_helpers!
       resource_segments, resource_ivars = [], []
       resource_config = self.resources_configuration[:self]
+      router = resource_config[:router]
 
       singleton   = self.resources_configuration[:self][:singleton]
       polymorphic = self.parents_symbols.include?(:polymorphic)
@@ -79,8 +80,8 @@ module InheritedResources
 
       # Generate parent url before we add resource instances.
       unless parents_symbols.empty?
-        generate_url_and_path_helpers nil,   :parent, resource_segments, resource_ivars
-        generate_url_and_path_helpers :edit, :parent, resource_segments, resource_ivars
+        generate_url_and_path_helpers router, nil,   :parent, resource_segments, resource_ivars
+        generate_url_and_path_helpers router, :edit, :parent, resource_segments, resource_ivars
       end
 
       # This is the default route configuration, later we have to deal with
@@ -128,17 +129,17 @@ module InheritedResources
         collection_segments << :index
       end
 
-      generate_url_and_path_helpers nil,   :collection, collection_segments, collection_ivars
-      generate_url_and_path_helpers :new,  :resource,   resource_segments,   new_ivars || collection_ivars
-      generate_url_and_path_helpers nil,   :resource,   resource_segments,   resource_ivars
-      generate_url_and_path_helpers :edit, :resource,   resource_segments,   resource_ivars
+      generate_url_and_path_helpers router, nil,   :collection, collection_segments, collection_ivars
+      generate_url_and_path_helpers router, :new,  :resource,   resource_segments,   new_ivars || collection_ivars
+      generate_url_and_path_helpers router, nil,   :resource,   resource_segments,   resource_ivars
+      generate_url_and_path_helpers router, :edit, :resource,   resource_segments,   resource_ivars
 
       if resource_config[:custom_actions]
         [*resource_config[:custom_actions][:resource]].each do | method |
-          generate_url_and_path_helpers method, :resource, resource_segments, resource_ivars
+          generate_url_and_path_helpers router, method, :resource, resource_segments, resource_ivars
         end
         [*resource_config[:custom_actions][:collection]].each do | method |
-          generate_url_and_path_helpers method, :resources, collection_segments, collection_ivars
+          generate_url_and_path_helpers router, method, :resources, collection_segments, collection_ivars
         end
       end
     end
@@ -171,7 +172,7 @@ module InheritedResources
       return segments, ivars
     end
 
-    def generate_url_and_path_helpers(prefix, name, resource_segments, resource_ivars) #:nodoc:
+    def generate_url_and_path_helpers(router, prefix, name, resource_segments, resource_ivars) #:nodoc:
       resource_segments, resource_ivars = handle_shallow_resource(prefix, name, resource_segments, resource_ivars)
 
       ivars       = resource_ivars.dup
@@ -207,6 +208,7 @@ module InheritedResources
         ivars    = ivars.join(', ')
       end
 
+      router = router ? "#{router}." : ''
       prefix = prefix ? "#{prefix}_" : ''
       ivars << (ivars.empty? ? 'given_options' : ', given_options')
 
@@ -214,12 +216,12 @@ module InheritedResources
         protected
           def #{prefix}#{name}_path(*given_args)
             given_options = given_args.extract_options!
-            #{prefix}#{segments}_path(#{ivars})
+            #{router}#{prefix}#{segments}_path(#{ivars})
           end
 
           def #{prefix}#{name}_url(*given_args)
             given_options = given_args.extract_options!
-            #{prefix}#{segments}_url(#{ivars})
+            #{router}#{prefix}#{segments}_url(#{ivars})
           end
       URL_HELPERS
     end

--- a/test/defaults_test.rb
+++ b/test/defaults_test.rb
@@ -10,7 +10,7 @@ end
 
 class PaintersController < InheritedResources::Base
   defaults :instance_name => 'malarz', :collection_name => 'malarze',
-           :resource_class => Malarz, :route_prefix => nil,
+           :resource_class => Malarz, :route_prefix => nil, :router => nil,
            :finder => :find_by_slug
 end
 


### PR DESCRIPTION
If you have a controller in an application that inherits from a controller in a mountable engine (isolated namespace) and the child controller is also inheriting views from the parent controller, then using IR's url helpers (e.g. collection_path, resource_path) in the parent views will fail. The reason is that the url helpers need to be prepended with the name of the router (i.e. 'main_app').

To solve this problem, I added a :router parameter to the defaults function that allows the user to specify a string for the appropriate router (e.g. 'main_app') for a particular controller. The parameter almost exactly mirrors the :route_prefix parameter, so it's a pretty low risk fix.
