### PR TITLE
Bump responders dependency version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     inherited_resources (1.3.1)
       has_scope (~> 0.5.0)
-      responders (~> 0.6)
+      responders (~> 0.9)
 
 GEM
   remote: http://rubygems.org/
@@ -78,7 +78,7 @@ GEM
     rake (0.9.2.2)
     rdoc (3.12)
       json (~> 1.4)
-    responders (0.8.0)
+    responders (0.9.1)
       railties (~> 3.1)
     sprockets (2.1.2)
       hike (~> 1.2)

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency("responders", "~> 0.6")
+  s.add_dependency("responders", "~> 0.9")
   s.add_dependency("has_scope",  "~> 0.5.0")
 end


### PR DESCRIPTION
Ran into some issues in a project that were fixed in a newer version of the responders gem. Not sure if there's a specific reason that this is locked back to the 0.6 series, but the tests pass and my app runs fine with the 0.9 series.
