### PR TITLE
add support for controller-based param whitelisting (ala strong parameters)

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -305,7 +305,7 @@ module InheritedResources
 
       # extract attributes from params
       def build_resource_params
-        rparams = [params[resource_request_name] || params[resource_instance_name] || {}]
+        rparams = [whitelisted_params || params[resource_request_name] || params[resource_instance_name] || {}]
         if without_protection_given?
           rparams << without_protection
         else
@@ -313,6 +313,11 @@ module InheritedResources
         end
 
         rparams
+      end
+
+      def whitelisted_params
+        whitelist_method = :"#{ resource_request_name }_params"
+        respond_to?(whitelist_method) && self.send(whitelist_method)
       end
 
       # checking if role given

--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -317,7 +317,7 @@ module InheritedResources
 
       def whitelisted_params
         whitelist_method = :"#{ resource_request_name }_params"
-        respond_to?(whitelist_method) && self.send(whitelist_method)
+        respond_to?(whitelist_method, true) && self.send(whitelist_method)
       end
 
       # checking if role given

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -18,6 +18,10 @@ protected
     @scopes_applied = true
     object
   end
+
+  def user_params
+    (params[:user] || {}).slice(:these)
+  end
 end
 
 module UserTestHelper
@@ -193,6 +197,12 @@ class CreateActionBaseTest < ActionController::TestCase
     post :create, :user => {:these => 'params'}
     assert_equal mock_user, assigns(:user)
     @controller.class.send(:without_protection, nil)
+  end
+
+  def test_supports_convention_for_constructing_whitelisted_resource_params
+    User.expects(:new).with({'these' => 'params'}).returns(mock_user(:save => true))
+    post :create, :user => {:these => 'params', :those => 'params'}
+    assert_equal mock_user, assigns(:user)
   end
 
   def test_redirect_to_the_created_user

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -19,6 +19,8 @@ protected
     object
   end
 
+private
+
   def user_params
     (params[:user] || {}).slice(:these)
   end


### PR DESCRIPTION
if the inherited resources controller has a method named <resource name>_params, it will be called to construct the params hash that will be used for create/update.
