### PR TITLE
Ensure subclassed IR controllers can correctly resolve their resource_class

### DIFF
--- a/app/controllers/inherited_resources/base.rb
+++ b/app/controllers/inherited_resources/base.rb
@@ -30,8 +30,7 @@ module InheritedResources
                       :parent_url, :parent_path,
                       :smart_resource_url, :smart_collection_url
 
-        self.class_attribute :resource_class, :instance_writer => false unless self.respond_to? :resource_class
-        self.class_attribute :parents_symbols,  :resources_configuration, :instance_writer => false
+        self.class_attribute :resource_class, :parents_symbols,  :resources_configuration, :instance_writer => false
 
         protected :resource_class, :parents_symbols, :resources_configuration,
           :resource_class?, :parents_symbols?, :resources_configuration?

--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -292,7 +292,7 @@ module InheritedResources
       #
       def initialize_resources_class_accessors! #:nodoc:
         # First priority is the namespaced model, e.g. User::Group
-        self.resource_class ||= begin
+        self.resource_class = begin
           namespaced_class = self.name.sub(/Controller/, '').singularize
           namespaced_class.constantize
         rescue NameError

--- a/test/subclass_test.rb
+++ b/test/subclass_test.rb
@@ -1,0 +1,19 @@
+require File.expand_path('test_helper', File.dirname(__FILE__))
+
+class Cheese
+end
+class Livarot
+end
+class CheesesController < InheritedResources::Base
+end
+class LivarotsController < CheesesController
+end
+class SubclassedResourceController < ActionController::TestCase
+  tests LivarotsController
+
+  def test_that_it_picked_the_subclass_model
+    # make public so we can test it
+    LivarotsController.send(:public, *LivarotsController.protected_instance_methods)
+    assert_equal Livarot, @controller.resource_class
+  end
+end

--- a/test/subclass_test.rb
+++ b/test/subclass_test.rb
@@ -17,3 +17,18 @@ class SubclassedResourceController < ActionController::TestCase
     assert_equal Livarot, @controller.resource_class
   end
 end
+
+class Roquefort
+end
+class RoquesController < CheesesController
+  defaults :resource_class => Roquefort
+end
+class SubclassedResourceWithCustomNameController < ActionController::TestCase
+  tests RoquesController
+
+  def test_that_it_picked_the_subclass_model
+    # make public so we can test it
+    RoquesController.send(:public, *RoquesController.protected_instance_methods)
+    assert_equal Roquefort, @controller.resource_class
+  end
+end


### PR DESCRIPTION
Until recently, it has been possible to inherit from an IR-controller. Although this wasn't exactly documented or tested behaviour - it worked, and I've certainly used it quite often. But it broke in recent history.

These couple of commits restore the behaviour, and make sure there are tests to match.

NB: this reverts some changes in commit b21aa27 which allow for resource_class to be overwritten by a method in the controller class (which breaks the class inheritance behaviour and is also not asserted by any tests). 

It seems b21aa27 is possibly redundant(?), since resource_class may be over-ridden in defaults anyway. And it looks a little tricky to be able to allow overriding resource_class with a method _and_ allowing controller inheritance. I've tried to find out more about b21aa27 but haven't seen much discussion on the point yet - see https://github.com/josevalim/inherited_resources/commit/b21aa27b218aa831592a449e554a2361bfc39d6f#app/controllers/inherited_resources/base.rb

Hopefully this pull request will put the matter up for consideration one way or the other. It kind of boils down to choosing if IR should:
(a) allow overriding resource_class with a method OR
(b) continuing to support the ability to subclass IR controllers OR
(c) dig deeper to see if we can do both (a) and (b)

Since both (a) and (b) are actually undocumented behaviours at this point, I'm not actually sure what the "right" answer is. Anyone?
