### PR TITLE
support create with three block arity

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -233,6 +233,18 @@ module InheritedResources
 
       # Used to allow to specify success and failure within just one block:
       #
+      #   # three block arity
+      #   def create
+      #     create! do |resource, success, failure|
+      #       success.html {
+      #         #current_user.tag(:resource, :on => :tags, :with => 'test,resource')
+      #         redirect_to url_for(resource)
+      #       }
+      #       failure.html { redirect_to root_url }
+      #     end
+      #   end
+      #
+      #   # two block arity
       #   def create
       #     create! do |success, failure|
       #       failure.html { redirect_to root_url }
@@ -246,6 +258,15 @@ module InheritedResources
         args = (with_chain(object) << options)
 
         case block.try(:arity)
+          when 3
+            respond_with(*args) do |responder|
+              blank_slate = InheritedResources::BlankSlate.new
+              if object.errors.empty?
+                block.call(object, responder, blank_slate)
+              else
+                block.call(object, blank_slate, responder)
+              end
+            end
           when 2
             respond_with(*args) do |responder|
               blank_slate = InheritedResources::BlankSlate.new


### PR DESCRIPTION
This pull request add ability for user wanted to access the new created resource.

With this pull request, you can write custom create as follow:

```
def create
  create! do |resource, success, failure|
    success.html { redirect_to url_for(resource) }
    failure.html { redirect_to root_url }
  end
end
```

I met this requirement when I use _acts-as-taggable-on_ gem, adding tag support for some entities. In that scene, I need to do thing likes `current_user.tag(resource, :on => tags, :with => params[:tags])`.

Hope this will useful.

Thanks.
