### PR TITLE
added params[:ids] = [1, 2, 3] support to collection actions

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -22,7 +22,9 @@ module InheritedResources
       def collection
         get_collection_ivar || begin
           c = end_of_association_chain
-          set_collection_ivar(c.respond_to?(:scoped) ? c.scoped : c.all)
+          coll = c.respond_to?(:scoped) ? c.scoped : c
+          coll = params[:ids] ? coll.find(params[:ids]) : coll.all
+          set_collection_ivar(coll)
         end
       end
 

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -82,6 +82,13 @@ class IndexActionBaseTest < ActionController::TestCase
     get :index
     assert_equal Array, assigns(:users).class
   end
+
+  def test_render_the_requested_users
+    user1, user2 = mock_user, mock_user
+    User.expects(:find).with(['1', '2']).returns([user1, user2])
+    get :index, :ids => ['1', '2']
+    assert_equal [user1, user2], assigns(:users)
+  end
 end
 
 class ShowActionBaseTest < ActionController::TestCase


### PR DESCRIPTION
Adds support for params[:ids] on collection actions, making the following URLs work as expected, while not breaking any existing functionality:
- `/users?ids[]=1&ids[]=2`
- `/users?ids=1`
- `/users`

This is a primitive support for batch API actions, currently I have only written a test for the `index` action, but since the change is in the underlying `collection` action, it should work for anything else that depends on `collection` too.

This pull request was inspired by batch API conventions that are emerging; specifically this was based on [ember.js](http://emberjs.com/)'s REST adapter, which maps a request of loading users with ID 1 and 2 to `GET /users?ids[]=1&ids[]=2`.
