### PR TITLE
Integrate with strong_parameters

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -539,6 +539,16 @@ And then you can rewrite the last example as:
       end
     end
 
+== Strong Parameters
+
+If your controller defines a method named permitted_params, Inherited Resources will call it where it would normally call params. This allows for easy integration with the strong_parameters gem:
+
+    def permitted_params
+      params.permit(:widget => [:permitted_field, :other_permitted_field])
+    end
+
+Note that this doesn't work if you use strong_parameters' require method instead of permit, because whereas permit returns the entire sanitized parameter hash, require returns only the sanitized params below the parameter you required.
+
 == Bugs and Feedback
 
 If you discover any bugs, please describe it in the issues tracker, including Rails and Inherited Resources versions.

--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -305,7 +305,8 @@ module InheritedResources
 
       # extract attributes from params
       def build_resource_params
-        rparams = [params[resource_request_name] || params[resource_instance_name] || {}]
+        parameters = respond_to?(:permitted_params) ? permitted_params : params
+        rparams = [parameters[resource_request_name] || parameters[resource_instance_name] || {}]
         if without_protection_given?
           rparams << without_protection
         else

--- a/test/strong_parameters_test.rb
+++ b/test/strong_parameters_test.rb
@@ -1,0 +1,34 @@
+require File.expand_path('test_helper', File.dirname(__FILE__))
+
+class Widget
+  extend ActiveModel::Naming
+end
+
+class WidgetsController < InheritedResources::Base
+end
+
+class StrongParametersTest < ActionController::TestCase
+  def setup
+    @controller = WidgetsController.new
+    @controller.stubs(:widget_url).returns("/")
+    @controller.stubs(:permitted_params).returns(:widget => {:permitted => 'param'})
+  end
+
+  def test_permitted_params_from_new
+    Widget.expects(:new).with(:permitted => 'param')
+    get :new, :widget => { :permitted => 'param', :prohibited => 'param' }
+  end
+
+  def test_permitted_params_from_create
+    Widget.expects(:new).with(:permitted => 'param').returns(mock(:save => true))
+    post :create, :widget => { :permitted => 'param', :prohibited => 'param' }
+  end
+
+  def test_permitted_params_from_update
+    mock_widget = mock
+    mock_widget.stubs(:class).returns(Widget)
+    mock_widget.expects(:update_attributes).with(:permitted => 'param')
+    Widget.expects(:find).with('42').returns(mock_widget)
+    put :update, :id => '42', :widget => {:permitted => 'param', :prohibited => 'param'}
+  end
+end


### PR DESCRIPTION
See also #236

We now check for a method `permitted_params` in `build_resource_params`, and use it instead of `params` if present. We're expecting `permitted_params` to be implemented using strong_parameters' `permit` method, like this:

```
def permitted_params
  params.permit(:widget => [:permitted_field, :other_permitted_field]) 
end
```

Note that this doesn't work if you use strong_parameters' `require` method, because whereas the above example returns a cleaned copy of `params`, `params.require(:widget).permit(:permitted_field, :other_permitted_field)` returns a cleaned copy of `params[:widget]`.
