### PR TITLE
Compatibility with Ruby 2.0

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -292,7 +292,7 @@ module InheritedResources
         if respond_to? :index
           url ||= collection_url rescue nil
         end
-        if respond_to? :parent
+        if respond_to? :parent, true
           url ||= parent_url rescue nil
         end
         url ||= root_url rescue nil

--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -267,7 +267,7 @@ module InheritedResources
       # It's extend by HasScopeHelpers.
       #
       def apply_scopes_if_available(target_object) #:nodoc:
-        respond_to?(:apply_scopes) ? apply_scopes(target_object) : target_object
+        respond_to?(:apply_scopes, true) ? apply_scopes(target_object) : target_object
       end
 
       # Symbols chain in base helpers return nothing. This is later overwriten


### PR DESCRIPTION
In Ruby 2.0 `respond_to?` has been changed to return false for protected methods. This results in `apply_scopes` not beeing called.

It can be fixed passing true as a second argument. Ruby 1.9 requires the second parameter to look for private methods. So this change does not break anything.

http://tenderlovemaking.com/2012/09/07/protected-methods-and-ruby-2-0.html
