### PR TITLE
Add license to gemspec

### DIFF
--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/josevalim/inherited_resources"
   s.description = "Inherited Resources speeds up development by making your controllers inherit all restful actions so you just have to focus on what is important."
   s.authors     = ['José Valim']
+  s.license     = "MIT"
 
   s.rubyforge_project = "inherited_resources"
 


### PR DESCRIPTION
Prior to this commit, the gemspec did not include the license, which
means that one can't use the rubygems API to automatically determine
licensing of vendored gems. This commit adds the licensing to the
gemspec.
