### PR TITLE
allow permitted_params to be a private method

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -312,7 +312,7 @@ module InheritedResources
 
       # extract attributes from params
       def build_resource_params
-        parameters = respond_to?(:permitted_params) ? permitted_params : params
+        parameters = respond_to?(:permitted_params, true) ? permitted_params : params
         rparams = [parameters[resource_request_name] || parameters[resource_instance_name] || {}]
         if without_protection_given?
           rparams << without_protection


### PR DESCRIPTION
The examples in the strong_parameters README show a private method
for parameter sanitization.  This tiny change allows for following
that pattern.
