### PR TITLE
strong parameter support refined to allow standard Rails 4 notation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ gemspec
 gem 'rails', '>= 3.2', '< 5'
 gem 'mocha'
 gem 'turn'
+
+group :test do
+  gem 'strong_parameters'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,10 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    strong_parameters (0.1.4)
+      actionpack (>= 3.2.0)
+      activemodel (>= 3.2.0)
+      railties (>= 3.2.0)
     thor (0.18.1)
     thread_safe (0.1.2)
       atomic
@@ -98,4 +102,5 @@ DEPENDENCIES
   inherited_resources!
   mocha
   rails (>= 3.2, < 5)
+  strong_parameters
   turn

--- a/README.md
+++ b/README.md
@@ -706,6 +706,16 @@ def build_resource_params
 end
 ```
 
+
+Instead you can stick to a standard Rails 4 notation (as rails scaffold generates) and write:
+
+    def widget_params
+      params.require(:widget).permit(:permitted_field, :other_permitted_field)
+    end
+
+In such case you should remove #permitted_params method because it has greater priority.
+
+
 ## Bugs and Feedback
 
 If you discover any bugs, please describe it in the issues tracker, including Rails and InheritedResources versions.

--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -316,9 +316,44 @@ module InheritedResources
         @resource_params ||= build_resource_params
       end
 
+      def resource_params_method_name
+        "#{resource_instance_name}_params"
+      end
+
+      # Returns hash of sanitized params in a form like
+      # `{:project => {:project_attribute => 'value'}}`
+      #
+      # This method makes use of `project_params` (or `smth_else_params`) which
+      # is a default Rails controller method for strong parameters definition.
+      #
+      # `permitted_params` is usually fired by method :new, :create, :update
+      # actions. Action :new usually has no parameters so strong parameters
+      # `require` directive raises a +ActionController::ParameterMissing+
+      # exception. `#permitted_params` rescues such exceptions in :new and
+      # returns an empty hash of parameters (which is reasonable default).
+      # If for any reasons you need something more specific, you can redefine
+      # this method in a way previous `inherited_resources` versions did:
+      #
+      #    # Unnecessary redefinition
+      #    def permitted_params
+      #      params.permit(:project => [:project_attribute])
+      #    end
+      #
+      def permitted_params
+        return nil  unless respond_to?(resource_params_method_name, true)
+        {resource_request_name => send(resource_params_method_name)}
+      rescue ActionController::ParameterMissing
+        # typically :new action
+        if params[:action].to_s == 'new'
+          {resource_request_name => {}}
+        else
+          raise
+        end
+      end
+
       # extract attributes from params
       def build_resource_params
-        parameters = respond_to?(:permitted_params, true) ? permitted_params : params
+        parameters = permitted_params || params
         rparams = [parameters[resource_request_name] || parameters[resource_instance_name] || {}]
         if without_protection_given?
           rparams << without_protection

--- a/test/strong_parameters_test.rb
+++ b/test/strong_parameters_test.rb
@@ -1,5 +1,9 @@
 require File.expand_path('test_helper', File.dirname(__FILE__))
 
+if ActionPack::VERSION::MAJOR == 3
+  require 'strong_parameters'
+end
+
 class Widget
   extend ActiveModel::Naming
 end
@@ -7,6 +11,7 @@ end
 class WidgetsController < InheritedResources::Base
 end
 
+# test usage of `permitted_params`
 class StrongParametersTest < ActionController::TestCase
   def setup
     @controller = WidgetsController.new
@@ -31,6 +36,84 @@ class StrongParametersTest < ActionController::TestCase
     mock_widget = mock
     mock_widget.stubs(:class).returns(Widget)
     mock_widget.expects(:update_attributes).with(:permitted => 'param')
+    Widget.expects(:find).with('42').returns(mock_widget)
+    put :update, :id => '42', :widget => {:permitted => 'param', :prohibited => 'param'}
+  end
+
+  # `permitted_params` has greater priority than `widget_params`
+  def test_with_permitted_and_resource_methods
+      @controller.stubs(:widget_params).returns(:permitted => 'another_param')
+      class << @controller
+        private :widget_params
+      end
+      Widget.expects(:new).with(:permitted => 'param')
+      get :new, :widget => { :permitted => 'param', :prohibited => 'param' }
+  end
+end
+
+# test usage of `widget_params`
+class StrongParametersWithoutPermittedParamsTest < ActionController::TestCase
+  def setup
+    @controller = WidgetsController.new
+    @controller.stubs(:widget_url).returns("/")
+    @controller.stubs(:widget_params).returns(:permitted => 'param')
+    class << @controller
+      private :widget_params
+    end
+  end
+
+  def test_permitted_params_from_new
+    Widget.expects(:new).with(:permitted => 'param')
+    get :new, :widget => { :permitted => 'param', :prohibited => 'param' }
+  end
+
+  def test_permitted_params_from_create
+    Widget.expects(:new).with(:permitted => 'param').returns(mock(:save => true))
+    post :create, :widget => { :permitted => 'param', :prohibited => 'param' }
+  end
+
+  def test_permitted_params_from_update
+    mock_widget = mock
+    mock_widget.stubs(:class).returns(Widget)
+    mock_widget.expects(:update_attributes).with(:permitted => 'param')
+    Widget.expects(:find).with('42').returns(mock_widget)
+    put :update, :id => '42', :widget => {:permitted => 'param', :prohibited => 'param'}
+  end
+end
+
+# test usage of `widget_params` integrated with strong parameters (not using stubs)
+class StrongParametersIntegrationTest < ActionController::TestCase
+  def setup
+    @controller = WidgetsController.new
+    @controller.stubs(:widget_url).returns("/")
+
+    class << @controller
+      define_method :widget_params do
+        params.require(:widget).permit(:permitted)
+      end
+      private :widget_params
+    end
+  end
+
+  def test_permitted_empty_params_from_new
+    Widget.expects(:new).with({})
+    get :new, {}
+  end
+
+  def test_permitted_params_from_new
+    Widget.expects(:new).with('permitted' => 'param')
+    get :new, :widget => { :permitted => 'param', :prohibited => 'param' }
+  end
+
+  def test_permitted_params_from_create
+    Widget.expects(:new).with('permitted' => 'param').returns(mock(:save => true))
+    post :create, :widget => { :permitted => 'param', :prohibited => 'param' }
+  end
+
+  def test_permitted_params_from_update
+    mock_widget = mock
+    mock_widget.stubs(:class).returns(Widget)
+    mock_widget.expects(:update_attributes).with('permitted' => 'param')
     Widget.expects(:find).with('42').returns(mock_widget)
     put :update, :id => '42', :widget => {:permitted => 'param', :prohibited => 'param'}
   end


### PR DESCRIPTION
This commit allows one to use standard rails 4 `params.require().permit()` notation.
It's done in such a way that this doesn't clash with `permitted_params` if it's already defined. But if it doesn't, then default `permitted_params` falls back to a permitting method with resource-specific name.
Method user should define is the same as scaffold generates and thus the same as other gems such as cancan will try to handle.
