### PR TITLE
Fixes tests which failed due to absence of ActiveRecord in tests.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,3 +44,18 @@ class ActiveSupport::TestCase
     @routes = InheritedResources::Routes
   end
 end
+
+# make possible testing with existence or absence of deprecated finders
+class ActiveRecord
+  class << self
+    attr_accessor :use_deprecated_finders
+    def const_defined?(name)
+      if name == :DeprecatedFinders
+        return use_deprecated_finders
+      else
+        super
+      end
+    end
+  end
+end
+ActiveRecord.use_deprecated_finders = false


### PR DESCRIPTION
Made it possible to test in existence or absence of `ActiveRecord::DeprecatedFinders`

Before this patch some of my tests failed due to check (`ActiveRecord.const_defined?(:DeprecatedFinders)`) of deprecated finders existence in `BaseHelpers#collection`.
Now one can explicitly set whether he wants to test in existence or absence of deprecated finders.
Now all tests doesn't use deprecated finders (and if turn it on they fail because appropriate methods were not defined). Probably it's wise to write also tests in case that deprecated finders defined.
