### PR TITLE
Use a safer check for :scoped being deprecated.

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -22,7 +22,7 @@ module InheritedResources
       def collection
         get_collection_ivar || begin
           c = end_of_association_chain
-          use_scoped = c.respond_to?(:scoped) && !ActiveRecord.const_defined?(:DeprecatedFinders)
+          use_scoped = c.respond_to?(:scoped) && !defined?(ActiveRecord::DeprecatedFinders)
           set_collection_ivar(use_scoped ? c.scoped : c.all)
         end
       end


### PR DESCRIPTION
This works even if ActiveRecord is not defined.

Fixes the test failure mentioned here: https://github.com/josevalim/inherited_resources/pull/273#issuecomment-18204924
