### PR TITLE
Don't use deprecated ActiveRecord::Relation#all.

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -22,8 +22,14 @@ module InheritedResources
       def collection
         get_collection_ivar || begin
           c = end_of_association_chain
-          use_scoped = c.respond_to?(:scoped) && !defined?(ActiveRecord::DeprecatedFinders)
-          set_collection_ivar(use_scoped ? c.scoped : c.all)
+          if defined?(ActiveRecord::DeprecatedFinders)
+            # ActiveRecord::Base#scoped and ActiveRecord::Relation#all
+            # are deprecated in Rails 4.  If it's a relation just use
+            # it, otherwise use .all to get a relation.
+            set_collection_ivar(c.is_a?(ActiveRecord::Relation) ? c : c.all)
+          else
+            set_collection_ivar(c.respond_to?(:scoped) ? c.scoped : c.all)
+          end
         end
       end
 


### PR DESCRIPTION
This fixes the following issue, in a cleaner way than was proposed in that thread: https://github.com/josevalim/inherited_resources/issues/290
