### PR TITLE
predicate methods for action type #collection_action? and #resource_action?

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -346,6 +346,14 @@ module InheritedResources
       def without_protection
         { :without_protection => self.resources_configuration[:self][:without_protection] }
       end
+
+      def resource_action?
+        self.class.send(:resource_actions).include? params[:action].to_sym
+      end
+
+      def collection_action?
+        self.class.send(:collection_actions).include? params[:action].to_sym
+      end
   end
 end
 

--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -75,6 +75,7 @@ module InheritedResources
         actions_to_remove = Array(options[:except])
         actions_to_remove += ACTIONS - actions_to_keep.map { |a| a.to_sym } unless actions_to_keep.first == :all
         actions_to_remove.map! { |a| a.to_sym }.uniq!
+        self.resources_configuration[:self][:removed_actions] = actions_to_remove
         (instance_methods.map { |m| m.to_sym } & actions_to_remove).each do |action|
           undef_method action, "#{action}!"
         end
@@ -252,6 +253,24 @@ module InheritedResources
         [*options[:collection]].each do | action |
           helper_method "#{action}_resources_path", "#{action}_resources_url"
         end
+      end
+
+      # list of resource actions
+      def resource_actions
+        [*self.resources_configuration[:self][:custom_actions][:resource]] + basic_resource_actions
+      end
+
+      # list of collection actions
+      def collection_actions
+        [*self.resources_configuration[:self][:custom_actions][:collection]] + basic_collection_actions
+      end
+
+      def basic_resource_actions
+        [:new, :create, :edit, :update, :show, :destroy] - [*self.resources_configuration[:self][:removed_actions]]
+      end
+
+      def basic_collection_actions
+        [:index] - [*self.resources_configuration[:self][:removed_actions]]
       end
 
       # Defines the role to use when creating or updating resource.

--- a/test/views/songs/delete.html.erb
+++ b/test/views/songs/delete.html.erb
@@ -1,0 +1,1 @@
+Delete HTML

--- a/test/views/songs/index.html.erb
+++ b/test/views/songs/index.html.erb
@@ -1,0 +1,1 @@
+Index HTML

--- a/test/views/songs/search.html.erb
+++ b/test/views/songs/search.html.erb
@@ -1,0 +1,1 @@
+Search HTML

--- a/test/views/songs/show.html.erb
+++ b/test/views/songs/show.html.erb
@@ -1,0 +1,1 @@
+Show HTML


### PR DESCRIPTION
new controller methods #resource_action? and #collection_action? which can be used for example in conditional filters to decorate resource but not collection.

```
before_filter :if => :resource_action? do
  @book = @book.decorate
end
```
