### PR TITLE
Fetch namespaced model in the namespaced controller firstly

### DIFF
--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -23,6 +23,17 @@ class DeansController < InheritedResources::Base
   belongs_to :school
 end
 
+module Library
+  class Category
+  end
+
+  class Subcategory
+  end
+
+  class SubcategoriesController < InheritedResources::Base
+  end
+end
+
 class ActionsClassMethodTest < ActionController::TestCase
   tests BooksController
 
@@ -130,5 +141,15 @@ class BelongsToErrorsTest < ActiveSupport::TestCase
     end
   ensure
     DeansController.send(:parents_symbols=, [:school])
+  end
+
+  def test_belongs_to_for_namespaced_controller_and_namespaced_model_fetches_model_in_the_namespace_firstly
+    Library::SubcategoriesController.send(:belongs_to, :category)
+    assert_equal Library::Category, Library::SubcategoriesController.resources_configuration[:category][:parent_class]
+  end
+
+  def test_belongs_to_without_namesoace_sets_parent_class_properly
+    FoldersController.send(:belongs_to, :book)
+    assert_equal Book, FoldersController.resources_configuration[:book][:parent_class]
   end
 end


### PR DESCRIPTION
I would like to make controller to look for model in namespace firstly when controller is namespaced.

Assume we have model in the module:

``` ruby
module Admin
  class User < ActiveRecord::Base
    belongs_to :group
  end
end
```

which belongs to group:

``` ruby
module Admin
  class Group < ActiveRecord::Base
    has_many :users
  end
end
```

I want to have controller with nested resource users for group:

``` ruby
module Admin
  class Users < InheritedResources::Base
    belongs_to :group
  end
end
```

Inherited resources doesn't find parent for users collection as expected because it doesn't try too look up it in the `Admin` module. It tries to find only `Group` model which is not exist.

This fix solves problem with getting model in the namespace firstly, and if it doesn't find it it tries to get model without namespace.

Note: it also ready to find class model in the nested space, for example `A::B::MyModel`.
