### PR TITLE
fix for resource_class default value definition

### DIFF
--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -312,7 +312,7 @@ module InheritedResources
       def initialize_resources_class_accessors! #:nodoc:
         # First priority is the namespaced model, e.g. User::Group
         self.resource_class ||= begin
-          namespaced_class = self.name.sub(/Controller/, '').singularize
+          namespaced_class = self.name.sub(/Controller$/, '').singularize
           namespaced_class.constantize
         rescue NameError
           nil
@@ -320,7 +320,7 @@ module InheritedResources
 
         # Second priority is the top namespace model, e.g. EngineName::Article for EngineName::Admin::ArticlesController
         self.resource_class ||= begin
-          namespaced_classes = self.name.sub(/Controller/, '').split('::')
+          namespaced_classes = self.name.sub(/Controller$/, '').split('::')
           namespaced_class = [namespaced_classes.first, namespaced_classes.last].join('::').singularize
           namespaced_class.constantize
         rescue NameError
@@ -329,7 +329,7 @@ module InheritedResources
 
         # Third priority the camelcased c, i.e. UserGroup
         self.resource_class ||= begin
-          camelcased_class = self.name.sub(/Controller/, '').gsub('::', '').singularize
+          camelcased_class = self.name.sub(/Controller$/, '').gsub('::', '').singularize
           camelcased_class.constantize
         rescue NameError
           nil


### PR DESCRIPTION
This fix solves problems with default value definition for resource_class accessor.

Example:
we have model

``` ruby
Controller::User
```

and Controller for it:

``` ruby
Controller::UsersController
```

Old behavior causes wrong definition of resource_class:

``` ruby
'Controller::UsersController'.sub(/Controller/, '').singularize # 'UsersController'
'UsersController'.constantize # raises exception and resource_class becomes nil
```

My solution is to substitute 'Controller' postfix from controller name. So Controller::UsersController matches Controller::User model
