### PR TITLE
Don't generate helper methods when resource's name is Resource

### DIFF
--- a/lib/inherited_resources/url_helpers.rb
+++ b/lib/inherited_resources/url_helpers.rb
@@ -216,6 +216,9 @@ module InheritedResources
       prefix = prefix ? "#{prefix}_" : ''
       ivars << (ivars.empty? ? 'given_options' : ', given_options')
 
+      # Don't define helpers if resource's name is "Resource" to prevent collisions
+      return if resource_class.to_s == 'Resource' && name != :collection
+
       class_eval <<-URL_HELPERS, __FILE__, __LINE__
         protected
           def #{prefix}#{name}_path(*given_args)

--- a/test/url_helpers_test.rb
+++ b/test/url_helpers_test.rb
@@ -152,6 +152,10 @@ class Button
   extend ActiveModel::Naming
 end
 
+class Resource
+  extend ActiveModel::Naming
+end
+
 class ButtonsController < InheritedResources::Base
   belongs_to :display, :window, :shallow => true
   custom_actions :resource => :delete, :collection => :search
@@ -160,6 +164,8 @@ end
 class ImageButtonsController < ButtonsController
 end
 
+class ResourcesController < InheritedResources::Base
+end
 
 # Create a TestHelper module with some helpers
 class UrlHelpersTest < ActiveSupport::TestCase
@@ -957,6 +963,36 @@ class UrlHelpersTest < ActiveSupport::TestCase
     controller.send("edit_resource_path")
     controller.expects("delete_image_button_path").once
     controller.send("delete_resource_path")
+  end
+
+  def test_generating_helper_methods
+    controller = ResourcesController.new
+    resource_methods = %w(new_resource_path new_resource_url resource_path resource_url edit_resource_path edit_resource_url)
+    resource_methods.each do |method|
+      assert_raise NoMethodError, "undefined method '#{method}'" do
+        controller.send(method)
+      end
+    end
+    assert_raise NoMethodError, "undefined method 'resources_path'" do
+      controller.send(:collection_url)
+    end
+    assert_raise NoMethodError, "undefined method 'resources_url'" do
+      controller.send(:collection_url)
+    end
+
+    controller = ButtonsController.new
+    button_methods = %w(new_button_path new_button_url button_path button_url edit_button_path edit_button_url)
+    resource_methods.zip(button_methods).each do |method, button_method|
+      assert_raise NoMethodError, "undefined method '#{button_method}'" do
+        controller.send(method)
+      end
+    end
+    assert_raise NoMethodError, "undefined method 'buttons_path'" do
+      controller.send(:collection_url)
+    end
+    assert_raise NoMethodError, "undefined method 'buttons_url'" do
+      controller.send(:collection_url)
+    end
   end
 
   def test_url_helpers_on_namespaced_resource_with_shallowed_route


### PR DESCRIPTION
I have troubles when I inherit `ResourcesController` from `InheritedResources::Base`: I try to use `resource_path` or `edit_resource_path` but application gets infinitive recursion and as a result I have exception:

``` ruby
SystemStackError - stack level too deep:
  (gem) activesupport-3.2.12/lib/active_support/core_ext/array/extract_options.rb:23:in `'
```

So I see here only one solution - don't define helper methods when resource's class name is "Resource". This fix is about it
