### PR TITLE
Update documentation of begin_of_association_chain

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -118,6 +118,9 @@ module InheritedResources
       # If the user actually scopes the url, you should use belongs_to method
       # and declare that projects belong to user.
       #
+      # If you return nil in your implementation, then your association chain will
+      # have no scope, i.e. you will show every object.
+      #
       def begin_of_association_chain
         nil
       end


### PR DESCRIPTION
Imagine you have the following:

``` Ruby
def begin_of_association_chain
  current_user.billing_record
end
```

Because of how begin_of_association_chain is implemented, if for some reason `current_user.billing_record` happens to be `nil` then your user will end up having access to every object because that's what the default implementation returns.

I propose adding something about this in the documentation because it's something that one might not realize until a user tells him.

I think it probably should also be noted in the README since it's not an obvious thing at first IMHO and many people might have not realized it, but I'd like to get your opinion before going any further... (in fact, the text is almost a draft)

cheers.
