### PR TITLE
Unnecessary modification of the class_name in belongs_to breaks class name

### DIFF
--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -175,7 +175,7 @@ module InheritedResources
           config[:parent_class] = options.delete(:parent_class) ||
             begin
               class_name = if options[:class_name]
-                options.delete(:class_name).to_s.pluralize.classify
+                options.delete(:class_name)
               else
                 namespace = self.name.deconstantize
                 model_name = symbol.to_s.pluralize.classify

--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -24,6 +24,9 @@ class DeansController < InheritedResources::Base
 end
 
 module Library
+  class Base
+  end
+
   class Category
   end
 
@@ -146,6 +149,11 @@ class BelongsToErrorsTest < ActiveSupport::TestCase
   def test_belongs_to_for_namespaced_controller_and_namespaced_model_fetches_model_in_the_namespace_firstly
     Library::SubcategoriesController.send(:belongs_to, :category)
     assert_equal Library::Category, Library::SubcategoriesController.resources_configuration[:category][:parent_class]
+  end
+
+  def test_belongs_to_for_namespaced_model_sets_parent_class_properly
+    Library::SubcategoriesController.send(:belongs_to, :library, :class_name => 'Library::Base')
+    assert_equal Library::Base, Library::SubcategoriesController.resources_configuration[:library][:parent_class]
   end
 
   def test_belongs_to_without_namespace_sets_parent_class_properly


### PR DESCRIPTION
I think that there is no need to modify string in class name `:class_name => 'Foo'` in `belongs_to`. According to the comments it was added for compability with **ActiveRecord** and here **belongs_to** only constantized.

Also it's destructive modification, it brakes class name in cases like:

``` ruby
'Library::Base'.to_s.pluralize.classify # => 'Library::Basis
```

Test added.
