### PR TITLE
fix belongs_to for models without namespace in namespaced controllers

### DIFF
--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -186,13 +186,12 @@ module InheritedResources
                   if klass.safe_constantize
                     break
                   else
+                    klass = nil
                     namespace = namespace.deconstantize
                   end
                 end
 
-                klass = model_name if klass.start_with?('::')
-
-                klass
+                klass || model_name
               end
               class_name.constantize
             rescue NameError => e

--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -143,6 +143,11 @@ class BelongsToErrorsTest < ActiveSupport::TestCase
     DeansController.send(:parents_symbols=, [:school])
   end
 
+  def test_belongs_to_for_namespaced_controller_and_model_without_namespace_fetches_model_without_namespace
+    Library::SubcategoriesController.send(:belongs_to, :book)
+    assert_equal Book, Library::SubcategoriesController.resources_configuration[:book][:parent_class]
+  end
+
   def test_belongs_to_for_namespaced_controller_and_namespaced_model_fetches_model_in_the_namespace_firstly
     Library::SubcategoriesController.send(:belongs_to, :category)
     assert_equal Library::Category, Library::SubcategoriesController.resources_configuration[:category][:parent_class]


### PR DESCRIPTION
Bug was introduced by this commit https://github.com/josevalim/inherited_resources/commit/630a2775fab351540fc9bd8aa0ce43d4d039f44a, and brake inherited_resources in such situation:

```
class Group < ActiveRecord::Base
end 
class User < ActiveRecord::Base
end 
module Admin
  class Users < InheritedResources::Base
    belongs_to :group
  end
end
```
