### PR TITLE
Added ability to change the default redirect order for actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,21 @@ end
 
 This controller redirect to parent window after all CUD actions.
 
+These default orders can be overridden using redirect_order and passing either a single
+symbol describing the preferred redirect (one of :resource, :collection, :parent, :root)
+or an array which determines the order for calculating the redirect. :only and :except 
+can be used to limit which of the :create, :update or :destroy actions should be overwritten.
+
+Example:
+
+```ruby
+class ChargersController < InheritedResources::Base
+  belongs_to :phone
+  redirect_order [:parent, :resource], :only => :destroy
+  redirect_order :collection, :except => [:destroy, :update]
+end
+```
+
 ## Success and failure scenarios on destroy
 
 The destroy action can also fail, this usually happens when you have a

--- a/lib/inherited_resources/actions.rb
+++ b/lib/inherited_resources/actions.rb
@@ -31,7 +31,7 @@ module InheritedResources
       object = build_resource
 
       if create_resource(object)
-        options[:location] ||= smart_resource_url
+        options[:location] ||= smart_resource_url(:create)
       end
 
       respond_with_dual_blocks(object, options, &block)
@@ -43,7 +43,7 @@ module InheritedResources
       object = resource
 
       if update_resource(object, resource_params)
-        options[:location] ||= smart_resource_url
+        options[:location] ||= smart_resource_url(:update)
       end
 
       respond_with_dual_blocks(object, options, &block)
@@ -53,7 +53,7 @@ module InheritedResources
     # DELETE /resources/1
     def destroy(options={}, &block)
       object = resource
-      options[:location] ||= smart_collection_url
+      options[:location] ||= smart_collection_url(:destroy)
 
       destroy_resource(object)
       respond_with_dual_blocks(object, options, &block)

--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -291,22 +291,49 @@ module InheritedResources
       end
 
       # URL to redirect to when redirect implies resource url.
-      def smart_resource_url
-        url = nil
-        if respond_to? :show
-          url = resource_url rescue nil
-        end
-        url ||= smart_collection_url
+      def smart_resource_url(action = nil)
+        order = order_for(action, :resource, :collection, :parent)
+        smart_url(*order)
       end
 
       # URL to redirect to when redirect implies collection url.
-      def smart_collection_url
-        url = nil
-        if respond_to? :index
-          url ||= collection_url rescue nil
+      def smart_collection_url(action = nil)
+        order = order_for(action, :collection, :parent)
+        smart_url(*order)
+      end
+
+      # Returns custom redirect order or default
+      def order_for(action, *default)
+        if action && resources_configuration[:redirect_order]
+          resources_configuration[:redirect_order].try(:[], action.to_sym) || default
+        else
+          default
         end
-        if respond_to? :parent, true
-          url ||= parent_url rescue nil
+      end
+
+      # Creates the smart URL to redirect to. Attempts to resolve URLs order specified
+      def smart_url(*order)
+        url = nil
+        order.each do |redirect_type|
+
+          case redirect_type
+          when :resource
+            if respond_to? :show
+              url ||= resource_url rescue nil
+            end
+          when :collection
+            if respond_to? :index
+              url ||= collection_url rescue nil
+            end
+          when :parent
+            if respond_to? :parent, true
+              url ||= parent_url rescue nil
+            end
+          else
+            url ||= root_url rescue nil
+          end
+
+          break if url
         end
         url ||= root_url rescue nil
       end

--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -285,6 +285,26 @@ module InheritedResources
         self.resources_configuration[:self][:without_protection] = flag
       end
 
+      # Defines a new redirect order for successful Create/Update/Delete actions.
+      #
+      # redirect_order [:parent, :collection]
+      # redirect_order :collection, :only => [:create, :update]
+      # redirect_order [:parent, :resource, :collection], :except => :destroy
+      #
+      def redirect_order(order, *actions)
+        options = actions.extract_options!
+        redirects_for = [:create, :update, :destroy]
+
+        redirects_for = redirects_for & [*options[:only]] if options[:only]
+        redirects_for = redirects_for - [*options[:except]] if options[:except]
+
+        resources_configuration[:redirect_order] ||= {}
+
+        redirects_for.each do |action|
+          resources_configuration[:redirect_order][action] = [*order]
+        end
+      end
+
     private
 
       def acts_as_singleton! #:nodoc:

--- a/test/redirect_order_test.rb
+++ b/test/redirect_order_test.rb
@@ -1,0 +1,50 @@
+require File.expand_path('test_helper', File.dirname(__FILE__))
+
+class Phone
+  extend ActiveModel::Naming
+end
+
+class Charger
+  extend ActiveModel::Naming
+end
+
+class ChargersController < InheritedResources::Base
+  belongs_to :phone
+  redirect_order [:root], :only => :create
+  redirect_order [:collection, :root], :only => :update
+  redirect_order [:parent, :root], :except => [:update, :create]
+end
+
+class RedirectAccordingToOrderTest < ActionController::TestCase
+  tests ChargersController
+
+  def setup
+    phone = mock
+    Phone.stubs(:find).returns(phone)
+    phone.stubs(:chargers).returns(Charger)
+    Charger.stubs(:save).returns(true)
+    Charger.stubs(:find).returns(Charger)
+  end
+
+  def test_redirect_root_after_create
+    Charger.stubs(:build).returns(Charger)
+    post :create, :phone_id => '13'
+    assert_redirected_to 'http://test.host/'
+  end
+
+  def test_redirect_collection_after_update
+    test_url = "http://test.host/phones/13/chargers"
+    Charger.stubs(:update_attributes).returns(true)
+    @controller.expects(:phone_chargers_url).returns(test_url)
+    put :update, :phone_id => '13'
+    assert_redirected_to test_url
+  end
+
+  def test_redirect_parent_after_destroy
+    test_url = "http://test.host/phones/13"
+    Charger.stubs(:destroy).returns(true)
+    @controller.expects(:phone_url).returns(test_url)
+    delete :destroy, :phone_id => '13'
+    assert_redirected_to test_url
+  end
+end


### PR DESCRIPTION
Hey, I've been using inherited resources a great deal lately and find myself constantly changing the redirect path after successful create or update. Came up with this nifty idea for allowing the order of the redirects for CUD to be overridden which saves you from having to defined each action with the short hand redirect. 

Could you have a look through the diff below and merge if you think it suitable, I've tried to keep all interfaces same and followed the styles and conventions when possible. I've added some new tests as well to ensure this new functionality is correct and amended the README with instructions on how to use this.

Thanks
.FxN
