### PR TITLE
checkout "association_chain" method for default behavior

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -133,17 +133,10 @@ module InheritedResources
       # current resource).
       #
       def association_chain
-        @association_chain ||= begin
-          symbol_chain = if resources_configuration[:self][:singleton]
-            symbols_for_association_chain.reverse
-          else
-            symbols_for_association_chain
-          end
-
-          symbol_chain.inject([begin_of_association_chain]) do |chain, symbol|
+        @association_chain ||=
+          symbols_for_association_chain.inject([begin_of_association_chain]) do |chain, symbol|
             chain << evaluate_parent(symbol, resources_configuration[symbol], chain.last)
           end.compact.freeze
-        end
       end
 
       # Overwrite this method to provide other interpolation options when

--- a/test/nested_singleton_test.rb
+++ b/test/nested_singleton_test.rb
@@ -29,17 +29,17 @@ end
 # /party/37/venue/address case
 class AddressController < InheritedResources::Base
   defaults :singleton => true
-  belongs_to :venue, :singleton => true do
-    belongs_to :party
+  belongs_to :party do
+    belongs_to :venue, :singleton => true
   end
 end
 
 #and the more pathological case
 class GeolocationController < InheritedResources::Base
   defaults :singleton => true
-  belongs_to :address, :singleton => true do
+  belongs_to :party do
     belongs_to :venue, :singleton => true do
-      belongs_to :party
+      belongs_to :address, :singleton => true
     end
   end
 end


### PR DESCRIPTION
Hello, dudes! :rage2:
I have a little trouble with nested controllers and singleton option.

There are my models:

``` ruby
class Speciality < ActiveRecord::Base
  has_many :subspecialities
end

class Subspeciality < ActiveRecord::Base
  belongs_to :speciality
  has_one :work_plan
end

class WorkPlan < ActiveRecord::Base
  belongs_to :subspeciality
end
```

and their controllers:

``` ruby
class SpecialitiesController < ApplicationController
  inherit_resources
end

class SubspecialitiesController < ApplicationController
  inherit_resources
end

class WorkPlansController < ApplicationController
  inherit_resources

  defaults :singleton => true

  belongs_to :speciality do
    belongs_to :subspeciality
  end
end
```

When I visit specialities/1/subspecialities/2/work_plan/new I got an error:

``` ruby
 undefined method `specialities' for #<Subspeciality:0x00000000000000>
```

I found on 138 line of https://github.com/josevalim/inherited_resources/blob/master/lib/inherited_resources/base_helpers.rb#L135-L147 symbols_for_association_chain reversed if singleton option is true.
Why was symbols_for_association_chain reversed? I can rewrite belongs_to in my controller in reverse order but why single option change default behavior?

PS

I checkouted the association_chain method to state before this commit 7f455095f55f1b9372ac28ce4e5cd8679b93a231 (https://github.com/josevalim/inherited_resources/commit/7f455095f55f1b9372ac28ce4e5cd8679b93a231#diff-9e560d176d0aba6271a143b4b0631e1d).
All tests are passed.
