### PR TITLE
When parent exists, make sure the created resource is associated

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -70,7 +70,7 @@ module InheritedResources
       #   end
       #
       def create_resource(object)
-        object.save
+        parent? ? parent.save : object.save
       end
 
       # Responsible for updating the resource in :update method. This allow you

--- a/test/belongs_to_test.rb
+++ b/test/belongs_to_test.rb
@@ -60,7 +60,8 @@ class BelongsToTest < ActionController::TestCase
   end
 
   def test_expose_a_newly_create_comment_on_create
-    Comment.expects(:build).with({'these' => 'params'}).returns(mock_comment(:save => true))
+    Comment.expects(:build).with({'these' => 'params'}).returns(mock_comment)
+    mock_post.expects(:save).returns(true)
     post :create, :post_id => '37', :comment => {:these => 'params'}
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)

--- a/test/belongs_to_with_shallow_test.rb
+++ b/test/belongs_to_with_shallow_test.rb
@@ -38,7 +38,8 @@ class BelongsToWithShallowTest < ActionController::TestCase
   end
 
   def test_expose_a_newly_create_tag_on_create
-    Tag.expects(:build).with({'these' => 'params'}).returns(mock_tag(:save => true))
+    Tag.expects(:build).with({'these' => 'params'}).returns(mock_tag)
+    mock_post.expects(:save).returns(true)
     post :create, :post_id => 'thirty_seven', :tag => {:these => 'params'}
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)

--- a/test/customized_belongs_to_test.rb
+++ b/test/customized_belongs_to_test.rb
@@ -46,7 +46,8 @@ class CustomizedBelongsToTest < ActionController::TestCase
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_create
-    Professor.stubs(:build).returns(mock_professor(:save => true))
+    Professor.stubs(:build).returns(mock_professor)
+    mock_school.expects(:save).returns(true)
     post :create, :school_title => 'nice'
     assert_equal mock_school, assigns(:great_school)
   end

--- a/test/multiple_nested_optional_belongs_to_test.rb
+++ b/test/multiple_nested_optional_belongs_to_test.rb
@@ -208,7 +208,8 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 	def test_expose_a_newly_created_project_with_student
 		Student.expects(:find).with('37').returns(mock_student)
 		mock_student.expects(:projects).returns(Project)
-		Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project(:save => true))
+		Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project)
+    mock_student.expects(:save).returns(true)
 		post :create, :student_id => '37', :project => { :these => 'params' }
 		assert_equal mock_student, assigns(:student)
 		assert_equal mock_project, assigns(:project)
@@ -217,16 +218,18 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 	def test_expose_a_newly_created_project_with_manager
 		Manager.expects(:find).with('37').returns(mock_manager)
 		mock_manager.expects(:projects).returns(Project)
-		Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project(:save => true))
+		Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project)
+    mock_manager.expects(:save).returns(true)
 		post :create, :manager_id => '37', :project => { :these => 'params' }
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_project, assigns(:project)
 	end
-	
+
 	def test_expose_a_newly_created_project_with_employee
 		Employee.expects(:find).with('37').returns(mock_employee)
 		mock_employee.expects(:projects).returns(Project)
-		Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project(:save => true))
+		Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project)
+    mock_employee.expects(:save).returns(true)
 		post :create, :employee_id => '37', :project => { :these => 'params' }
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal mock_project, assigns(:project)
@@ -237,7 +240,8 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		mock_manager.expects(:employees).returns(Employee)
 		Employee.expects(:find).with('42').returns(mock_employee)
 		mock_employee.expects(:projects).returns(Project)
-		Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project(:save => true))
+		Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project)
+    mock_employee.expects(:save).returns(true)
 		post :create, :manager_id => '37', :employee_id => '42', :project => { :these => 'params' }
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_employee, assigns(:employee)

--- a/test/nested_belongs_to_test.rb
+++ b/test/nested_belongs_to_test.rb
@@ -65,7 +65,7 @@ class NestedBelongsToTest < ActionController::TestCase
 
   def test_assigns_country_and_state_and_city_on_create
     City.expects(:build).with({'these' => 'params'}).returns(mock_city)
-    mock_city.expects(:save).returns(true)
+    mock_state.expects(:save).returns(true)
     post :create, :state_id => '37', :country_id => '13', :city => {:these => 'params'}
 
     assert_equal mock_country, assigns(:country)
@@ -82,7 +82,7 @@ class NestedBelongsToTest < ActionController::TestCase
     assert_equal mock_state, assigns(:state)
     assert_equal mock_city, assigns(:city)
   end
-  
+
   def test_assigns_country_and_state_and_city_on_destroy
     City.expects(:find).with('42').returns(mock_city)
     mock_city.expects(:destroy)

--- a/test/nested_belongs_to_with_shallow_test.rb
+++ b/test/nested_belongs_to_with_shallow_test.rb
@@ -71,7 +71,7 @@ class NestedBelongsToWithShallowTest < ActionController::TestCase
     Shelf.expects(:find).with('37').twice.returns(mock_shelf)
 
     Plate.expects(:build).with({'these' => 'params'}).returns(mock_plate)
-    mock_plate.expects(:save).returns(true)
+    mock_shelf.expects(:save).returns(true)
     post :create, :shelf_id => '37', :plate => {:these => 'params'}
 
     assert_equal mock_dresser, assigns(:dresser)

--- a/test/nested_model_with_shallow_test.rb
+++ b/test/nested_model_with_shallow_test.rb
@@ -59,7 +59,8 @@ class NestedModelWithShallowTest < ActionController::TestCase
 
   def test_expose_a_newly_create_group_with_speciality
     Speciality.expects(:find).with('37').twice.returns(mock_speciality)
-    Plan::Group.expects(:build).with({'these' => 'params'}).returns(mock_group(:save => true))
+    Plan::Group.expects(:build).with({'these' => 'params'}).returns(mock_group)
+    mock_speciality.expects(:save).returns(true)
     post :create, :speciality_id => '37', :group => {'these' => 'params'}
     assert_equal mock_group, assigns(:group)
   end

--- a/test/nested_singleton_test.rb
+++ b/test/nested_singleton_test.rb
@@ -11,7 +11,7 @@ class Venue
   extend ActiveModel::Naming
 end
 
-class Address 
+class Address
   extend ActiveModel::Naming
 end
 
@@ -25,7 +25,7 @@ class VenueController < InheritedResources::Base
   belongs_to :party
 end
 
-# for the slightly pathological 
+# for the slightly pathological
 # /party/37/venue/address case
 class AddressController < InheritedResources::Base
   defaults :singleton => true
@@ -92,7 +92,7 @@ class NestedSingletonTest < ActionController::TestCase
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)
   end
-  
+
   def test_expose_the_address_on_edit
     Party.expects(:find).with('37').returns(mock_party)
     mock_party.expects(:venue).returns(mock_venue)
@@ -118,7 +118,8 @@ class NestedSingletonTest < ActionController::TestCase
   def test_expose_a_newly_create_address_on_create
     Party.expects(:find).with('37').returns(mock_party)
     mock_party.expects(:venue).returns(mock_venue)
-    mock_venue.expects(:build_address).with({'these' => 'params'}).returns(mock_address(:save => true))
+    mock_venue.expects(:build_address).with({'these' => 'params'}).returns(mock_address)
+    mock_venue.expects(:save).returns(true)
     post :create, :party_id => '37', :address => {:these => 'params'}
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)

--- a/test/optional_belongs_to_test.rb
+++ b/test/optional_belongs_to_test.rb
@@ -86,7 +86,8 @@ class OptionalTest < ActionController::TestCase
   def test_expose_a_newly_create_product_with_category
     Category.expects(:find).with('37').returns(mock_category)
     mock_category.expects(:products).returns(Product)
-    Product.expects(:build).with({'these' => 'params'}).returns(mock_product(:save => true))
+    Product.expects(:build).with({'these' => 'params'}).returns(mock_product)
+    mock_category.expects(:save).returns(true)
     post :create, :category_id => '37', :product => {:these => 'params'}
     assert_equal mock_category, assigns(:category)
     assert_equal mock_product, assigns(:product)

--- a/test/polymorphic_test.rb
+++ b/test/polymorphic_test.rb
@@ -63,7 +63,8 @@ class PolymorphicFactoriesTest < ActionController::TestCase
   end
 
   def test_expose_a_newly_create_employee_on_create
-    Employee.expects(:build).with({'these' => 'params'}).returns(mock_employee(:save => true))
+    Employee.expects(:build).with({'these' => 'params'}).returns(mock_employee)
+    mock_factory.expects(:save).returns(true)
     post :create, :factory_id => '37', :employee => {:these => 'params'}
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
@@ -150,7 +151,8 @@ class PolymorphicCompanyTest < ActionController::TestCase
   end
 
   def test_expose_a_newly_create_employee_on_create
-    Employee.expects(:build).with({'these' => 'params'}).returns(mock_employee(:save => true))
+    Employee.expects(:build).with({'these' => 'params'}).returns(mock_employee)
+    mock_company.expects(:save).returns(true)
     post :create, :company_id => '37', :employee => {:these => 'params'}
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)

--- a/test/singleton_test.rb
+++ b/test/singleton_test.rb
@@ -52,7 +52,8 @@ class SingletonTest < ActionController::TestCase
 
   def test_expose_a_newly_create_manager_on_create
     Store.expects(:find).with('37').returns(mock_store)
-    mock_store.expects(:build_manager).with({'these' => 'params'}).returns(mock_manager(:save => true))
+    mock_store.expects(:build_manager).with({'these' => 'params'}).returns(mock_manager)
+    mock_store.expects(:save).returns(true)
     post :create, :store_id => '37', :manager => {:these => 'params'}
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)


### PR DESCRIPTION
Perhaps I'm missing something really obvious, but I was surprised to find that when a resource has a parent, it does not get created under the parent.

This PR makes sure that a child object is correctly associated with its parent upon its creation.
