### PR TITLE
Revert "Unsplatting simplified"

### DIFF
--- a/lib/inherited_resources/actions.rb
+++ b/lib/inherited_resources/actions.rb
@@ -4,25 +4,25 @@ module InheritedResources
 
     # GET /resources
     def index(options={}, &block)
-      respond_with(*with_chain(collection), options, &block)
+      respond_with(*(with_chain(collection) << options), &block)
     end
     alias :index! :index
 
     # GET /resources/1
     def show(options={}, &block)
-      respond_with(*with_chain(resource), options, &block)
+      respond_with(*(with_chain(resource) << options), &block)
     end
     alias :show! :show
 
     # GET /resources/new
     def new(options={}, &block)
-      respond_with(*with_chain(build_resource), options, &block)
+      respond_with(*(with_chain(build_resource) << options), &block)
     end
     alias :new! :new
 
     # GET /resources/1/edit
     def edit(options={}, &block)
-      respond_with(*with_chain(resource), options, &block)
+      respond_with(*(with_chain(resource) << options), &block)
     end
     alias :edit! :edit
 

--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -222,7 +222,7 @@ module InheritedResources
       def polymorphic_belongs_to(*symbols, &block)
         options = symbols.extract_options!
         options.merge!(:polymorphic => true)
-        belongs_to(*symbols, options, &block)
+        belongs_to(*symbols << options, &block)
       end
 
       # A quick method to declare singleton belongs to.
@@ -230,7 +230,7 @@ module InheritedResources
       def singleton_belongs_to(*symbols, &block)
         options = symbols.extract_options!
         options.merge!(:singleton => true)
-        belongs_to(*symbols, options, &block)
+        belongs_to(*symbols << options, &block)
       end
 
       # A quick method to declare optional belongs to.
@@ -238,7 +238,7 @@ module InheritedResources
       def optional_belongs_to(*symbols, &block)
         options = symbols.extract_options!
         options.merge!(:optional => true)
-        belongs_to(*symbols, options, &block)
+        belongs_to(*symbols << options, &block)
       end
 
       # Defines custom restful actions by resource or collection basis.
@@ -379,7 +379,7 @@ module InheritedResources
       def create_custom_action(resource_or_collection, action)
         class_eval <<-CUSTOM_ACTION, __FILE__, __LINE__
           def #{action}(options={}, &block)
-            respond_with(*with_chain(#{resource_or_collection}), options, &block)
+            respond_with(*(with_chain(#{resource_or_collection}) << options), &block)
           end
           alias :#{action}! :#{action}
           protected :#{action}!


### PR DESCRIPTION
This reverts PR #279 commit bf659843dccec5b72b105e6ff9a581a84b9d53ef, which broke Ruby 1.8.7 compatibility.
