### PR TITLE
Parent scopes added

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    inherited_resources (1.4.0)
+    inherited_resources (1.4.1)
       has_scope (~> 0.6.0.rc)
       responders (~> 1.0.0.rc)
 
@@ -69,7 +69,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.1.0)
-    responders (1.0.0.rc)
+    responders (1.0.0)
       railties (>= 3.2, < 5)
     sprockets (2.10.0)
       hike (~> 1.2)

--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -141,7 +141,7 @@ module InheritedResources
         options.symbolize_keys!
         options.assert_valid_keys(:class_name, :parent_class, :instance_name, :param,
                                   :finder, :route_name, :collection_name, :singleton,
-                                  :polymorphic, :optional, :shallow)
+                                  :polymorphic, :optional, :shallow, :scope)
 
         optional    = options.delete(:optional)
         shallow     = options.delete(:shallow)
@@ -185,6 +185,7 @@ module InheritedResources
           config[:param]           = options.delete(:param) || :"#{symbol}_id"
           config[:route_name]      = options.delete(:route_name) || symbol
           config[:finder]          = finder || :find
+          config[:scope]           = options.delete(:scope)
         end
 
         if block_given?


### PR DESCRIPTION
Useful option to work with different scopes.
Fixes situation, when in a parent controller resource has limited scope, but you can access nested resource through direct url like _localhost:3000/projects/289/comments/new_.
