### PR TITLE
Changed default parent class of InheritedResources::Base.

### DIFF
--- a/app/controllers/inherited_resources/base.rb
+++ b/app/controllers/inherited_resources/base.rb
@@ -8,7 +8,11 @@ module InheritedResources
   # call <tt>default</tt> class method, call <<tt>actions</tt> class method
   # or overwrite some helpers in the base_helpers.rb file.
   #
-  class Base < ::ApplicationController
+  # By default the base class inherits from ActionController::Base, since it is not
+  # given an ::ApplicationController exists in every Rails application.
+  # This can be changed through an initializer. eg.
+  #   InheritedResources::Railtie.config.parent_controller = "ApplicationController"
+  class Base < InheritedResources.parent_controller
     # Overwrite inherit_resources to add specific InheritedResources behavior.
     def self.inherit_resources(base)
       base.class_eval do

--- a/lib/inherited_resources.rb
+++ b/lib/inherited_resources.rb
@@ -22,8 +22,18 @@ module InheritedResources
     Responders::FlashResponder.flash_keys = array
   end
 
+  def parent_controller
+    @parent_controller ||= begin
+      klass = Railtie.config.parent_controller
+      klass = klass.constantize if klass.is_a? String
+      klass
+    end
+  end
+
   class Railtie < ::Rails::Engine
     config.inherited_resources = InheritedResources
+    config.parent_controller = "ActionController::Base"
+
     if config.respond_to?(:app_generators)
       config.app_generators.scaffold_controller = :inherited_resources_controller
     else

--- a/lib/inherited_resources.rb
+++ b/lib/inherited_resources.rb
@@ -22,7 +22,7 @@ module InheritedResources
     Responders::FlashResponder.flash_keys = array
   end
 
-  def parent_controller
+  def self.parent_controller
     @parent_controller ||= begin
       klass = Railtie.config.parent_controller
       klass = klass.constantize if klass.is_a? String


### PR DESCRIPTION
I always had this issue with namespaced applications, but that could be easily overcome by defining an pointer constant to the namespaced ApplicationController.

Now I have a namespaced Rails Application, that depends on an namespaced Rails Engine, that uses active_admin, which uses inherited_resources. And none, including the application itself have an ApplicationController in the root.

Also I would raise the discussion about moving Base to the lib directory, and have maybe an InheritedResources::ApplicationController < ::ApplicationController; inherit_resources; end 
if one needs it.

I don't really understand your architecture of tests, otherwise I would have written one for this change.
For backwards compatibility I would suggest an generator or something that creates an initializer. 

Greetings.
