### PR TITLE
Undefine url helpers if actions excluded

### DIFF
--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -77,6 +77,9 @@ module InheritedResources
         actions_to_remove.map! { |a| a.to_sym }.uniq!
         (instance_methods.map { |m| m.to_sym } & actions_to_remove).each do |action|
           undef_method action, "#{action}!"
+          undef_method "#{action}_resource_url" if [:new, :edit].include?(action)
+          undef_method :resource_url if action == :show
+          undef_method :collection_url if action == :index
         end
       end
 


### PR DESCRIPTION
For example i want to create controller without 2 actions. And I have another controllers but with those actions. 

``` ruby
class Admin::UsersController < AdminController
  inherit_resources
  actions :all, except: [:create, :new]
  # ...
end
```

All controllers share common partial

``` ruby
    - if controller.respond_to?(:new_resource_url, true)
      span= link_to '+', new_resource_url
```

Without undefining url helpers I can't call respond_to?(:new_resource_url) and it seems not smart, having methods(url helpers) witch don't work.

Feel free to close or suggesting another way to do it.
Thanks.
