### PR TITLE
 #325 fix: set belongs_to properly for namespaced controller and non_namespaced model

### DIFF
--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -148,6 +148,11 @@ class BelongsToErrorsTest < ActiveSupport::TestCase
     assert_equal Library::Category, Library::SubcategoriesController.resources_configuration[:category][:parent_class]
   end
 
+  def test_belongs_to_for_namespaced_controller_and_non_namespaced_model_sets_parent_class_properly
+    Library::SubcategoriesController.send(:belongs_to, :book)
+    assert_equal Book, Library::SubcategoriesController.resources_configuration[:book][:parent_class]
+  end
+
   def test_belongs_to_without_namespace_sets_parent_class_properly
     FoldersController.send(:belongs_to, :book)
     assert_equal Book, FoldersController.resources_configuration[:book][:parent_class]


### PR DESCRIPTION
this pull request fix issue #325
This issue occurred when controller is in namespace but use model without namespace.
