### PR TITLE
Test case for PR #367

### DIFF
--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -148,6 +148,11 @@ class BelongsToErrorsTest < ActiveSupport::TestCase
     assert_equal Library::Category, Library::SubcategoriesController.resources_configuration[:category][:parent_class]
   end
 
+  def test_belongs_to_for_namespaced_controller_and_non_namespaced_model_sets_parent_class_properly
+    Library::SubcategoriesController.send(:belongs_to, :book)
+    assert_equal Book, Library::SubcategoriesController.resources_configuration[:book][:parent_class]
+  end
+
   def test_belongs_to_without_namespace_sets_parent_class_properly
     FoldersController.send(:belongs_to, :book)
     assert_equal Book, FoldersController.resources_configuration[:book][:parent_class]


### PR DESCRIPTION
Tests that `belongs_to` assigns the `parent_class` properly for a namespaced controller and a non-namespaced model.
