### PR TITLE
Minimal fix for parent class issue.

### DIFF
--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -182,8 +182,9 @@ module InheritedResources
 
                 klass = model_name
                 while namespace != ''
-                  klass = "#{namespace}::#{model_name}"
-                  if klass.safe_constantize
+                  new_klass = "#{namespace}::#{model_name}"
+                  if new_klass.safe_constantize
+                    klass = new_klass
                     break
                   else
                     namespace = namespace.deconstantize

--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -148,6 +148,11 @@ class BelongsToErrorsTest < ActiveSupport::TestCase
     assert_equal Library::Category, Library::SubcategoriesController.resources_configuration[:category][:parent_class]
   end
 
+  def test_belongs_to_for_namespaced_controller_and_non_namespaced_model_sets_parent_class_properly
+    Library::SubcategoriesController.send(:belongs_to, :book)
+    assert_equal Book, Library::SubcategoriesController.resources_configuration[:book][:parent_class]
+  end
+
   def test_belongs_to_without_namespace_sets_parent_class_properly
     FoldersController.send(:belongs_to, :book)
     assert_equal Book, FoldersController.resources_configuration[:book][:parent_class]


### PR DESCRIPTION
This is a minimal fix for the parent class issue in the case of a namespaced controller and a non-namespaced model.  It incorporates the spec provided in PR #369 , and that spec passes for this PR.  The changes made are less extensive than #367 which seems to have a bit of controversy.

Essentially all this PR does is defer setting the `klass` variable until the code has confirmed that the constant corresponding to the newly namespaced class name exists.  I'm hoping this will be a low-controversy alternative to #367 , and that we can expedite merging this PR.  This is a blocking issue for ActiveAdmin, as discussed here - https://github.com/activeadmin/activeadmin/pull/3193
