### PR TITLE
Fix Specs - Issue #381

### DIFF
--- a/app/controllers/inherited_resources/base.rb
+++ b/app/controllers/inherited_resources/base.rb
@@ -31,7 +31,7 @@ module InheritedResources
                       :smart_resource_url, :smart_collection_url
 
         self.class_attribute :resource_class, :instance_writer => false unless self.respond_to? :resource_class
-        self.class_attribute :parents_symbols,  :resources_configuration, :instance_writer => false
+        self.class_attribute :parents_symbols, :resources_configuration, :instance_writer => false
 
         protected :resource_class, :parents_symbols, :resources_configuration,
           :resource_class?, :parents_symbols?, :resources_configuration?

--- a/lib/inherited_resources/actions.rb
+++ b/lib/inherited_resources/actions.rb
@@ -64,4 +64,3 @@ module InheritedResources
     protected :index!, :show!, :new!, :create!, :edit!, :update!, :destroy!
   end
 end
-

--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -383,4 +383,3 @@ module InheritedResources
       end
   end
 end
-

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -250,11 +250,16 @@ class UpdateActionBaseTest < ActionController::TestCase
   end
 
   def test_redirect_to_the_users_list_if_show_undefined
+    klass = UsersController.dup
+
     @controller.class.send(:actions, :all, :except => :show)
     User.stubs(:find).returns(mock_user(:update_attributes => true))
     @controller.expects(:collection_url).returns('http://test.host/')
     put :update
     assert_redirected_to 'http://test.host/'
+
+    Object.send(:remove_const, :UsersController) if defined?(UsersController)
+    Object.const_set(:UsersController, klass)
   end
 
   def test_show_flash_message_when_success


### PR DESCRIPTION
We remove the show method when we call .send(:actions, :all, :except => :show) as we can see [here](https://github.com/josevalim/inherited_resources/blob/master/lib/inherited_resources/class_methods.rb#L78-L80).
So we can't call `actions` twice to redo the method, which I think is really fair.

This PR fixes the specs which sometimes want the method back. 

https://github.com/josevalim/inherited_resources/issues/381
