### PR TITLE
allow test cases to safely modify controller class by making it unique p...

### DIFF
--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -12,7 +12,11 @@ class UsersController < AccountsController
   respond_to :js, :only => [:create, :update, :destroy]
   attr_reader :scopes_applied
 
-protected
+  def self.name
+    "UsersController"
+  end
+
+  protected
 
   def apply_scopes(object)
     @scopes_applied = true
@@ -22,7 +26,8 @@ end
 
 module UserTestHelper
   def setup
-    @controller          = UsersController.new
+    @controller_class    = Class.new(UsersController)
+    @controller          = @controller_class.new
     @controller.request  = @request  = ActionController::TestRequest.new
     @controller.response = @response = ActionController::TestResponse.new
     @controller.stubs(:user_url).returns("/")

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -175,15 +175,13 @@ class CreateActionBaseTest < ActionController::TestCase
     User.expects(:new).with({'these' => 'params'}, {:as => :admin}).returns(mock_user(:save => true))
     post :create, :user => {:these => 'params'}
     assert_equal mock_user, assigns(:user)
-    @controller.class.send(:with_role, nil)
   end
 
   def test_expose_a_newly_create_user_when_saved_with_success_and_without_protection_setted
-   @controller.class.send(:without_protection, true)
+    @controller.class.send(:without_protection, true)
     User.expects(:new).with({'these' => 'params'}, {:without_protection => true}).returns(mock_user(:save => true))
     post :create, :user => {:these => 'params'}
     assert_equal mock_user, assigns(:user)
-    @controller.class.send(:without_protection, nil)
   end
 
   def test_redirect_to_the_created_user
@@ -235,7 +233,6 @@ class UpdateActionBaseTest < ActionController::TestCase
     mock_user.expects(:update_attributes).with({'these' => 'params'}, {:as => :admin}).returns(true)
     put :update, :id => '42', :user => {:these => 'params'}
     assert_equal mock_user, assigns(:user)
-    @controller.class.send(:with_role, nil)
   end
 
   def test_update_the_requested_object_when_setted_without_protection
@@ -244,7 +241,6 @@ class UpdateActionBaseTest < ActionController::TestCase
     mock_user.expects(:update_attributes).with({'these' => 'params'}, {:without_protection => true}).returns(true)
     put :update, :id => '42', :user => {:these => 'params'}
     assert_equal mock_user, assigns(:user)
-    @controller.class.send(:without_protection, nil)
   end
 
   def test_redirect_to_the_updated_user

--- a/test/strong_parameters_test.rb
+++ b/test/strong_parameters_test.rb
@@ -6,6 +6,7 @@ end
 
 class Widget
   extend ActiveModel::Naming
+  include ActiveModel::Conversion
 end
 
 class WidgetsController < InheritedResources::Base
@@ -36,6 +37,9 @@ class StrongParametersTest < ActionController::TestCase
     mock_widget = mock
     mock_widget.stubs(:class).returns(Widget)
     mock_widget.expects(:update_attributes).with(:permitted => 'param')
+    mock_widget.stubs(:persisted?).returns(true)
+    mock_widget.stubs(:to_model).returns(mock_widget)
+    mock_widget.stubs(:model_name).returns(Widget.model_name)
     Widget.expects(:find).with('42').returns(mock_widget)
     put :update, :id => '42', :widget => {:permitted => 'param', :prohibited => 'param'}
   end
@@ -76,6 +80,9 @@ class StrongParametersWithoutPermittedParamsTest < ActionController::TestCase
     mock_widget = mock
     mock_widget.stubs(:class).returns(Widget)
     mock_widget.expects(:update_attributes).with(:permitted => 'param')
+    mock_widget.stubs(:persisted?).returns(true)
+    mock_widget.stubs(:to_model).returns(mock_widget)
+    mock_widget.stubs(:model_name).returns(Widget.model_name)
     Widget.expects(:find).with('42').returns(mock_widget)
     put :update, :id => '42', :widget => {:permitted => 'param', :prohibited => 'param'}
   end
@@ -114,6 +121,9 @@ class StrongParametersIntegrationTest < ActionController::TestCase
     mock_widget = mock
     mock_widget.stubs(:class).returns(Widget)
     mock_widget.expects(:update_attributes).with('permitted' => 'param')
+    mock_widget.stubs(:persisted?).returns(true)
+    mock_widget.stubs(:to_model).returns(mock_widget)
+    mock_widget.stubs(:model_name).returns(Widget.model_name)
     Widget.expects(:find).with('42').returns(mock_widget)
     put :update, :id => '42', :widget => {:permitted => 'param', :prohibited => 'param'}
   end

--- a/test/url_helpers_test.rb
+++ b/test/url_helpers_test.rb
@@ -1,34 +1,34 @@
 require File.expand_path('test_helper', File.dirname(__FILE__))
 
-class Universe
+class ModelBase
   extend ActiveModel::Naming
+  include ActiveModel::Conversion
+end
+
+class Universe < ModelBase
 end
 class UniversesController < InheritedResources::Base
   defaults :singleton => true, :route_instance_name => 'universum'
 end
 
-class House
-  extend ActiveModel::Naming
+class House < ModelBase
 end
 class HousesController < InheritedResources::Base
 end
 
-class News
-  extend ActiveModel::Naming
+class News < ModelBase
 end
 class NewsController < InheritedResources::Base
 end
 
-class Backpack
-  extend ActiveModel::Naming
+class Backpack < ModelBase
 end
 module Admin; end
 class Admin::BackpacksController < InheritedResources::Base
   defaults :route_collection_name => 'tour_backpacks'
 end
 
-class Table
-  extend ActiveModel::Naming
+class Table < ModelBase
 end
 class TablesController < InheritedResources::Base
   belongs_to :house
@@ -64,27 +64,25 @@ end
 
 class Bed
   extend ActiveModel::Naming
+  include ActiveModel::Conversion
 end
 class BedsController < InheritedResources::Base
   optional_belongs_to :house, :building
 end
 
-class Sheep
-  extend ActiveModel::Naming
+class Sheep < ModelBase
 end
 class SheepController < InheritedResources::Base
   belongs_to :news, :table, :polymorphic => true
 end
 
-class Fish
-  extend ActiveModel::Naming
+class Fish < ModelBase
 end
 class FishController < InheritedResources::Base
   belongs_to :bed, :shallow => true
 end
 
-class Desk
-  extend ActiveModel::Naming
+class Desk < ModelBase
 end
 module Admin
   class DesksController < InheritedResources::Base
@@ -92,8 +90,7 @@ module Admin
   end
 end
 
-class Dish
-  extend ActiveModel::Naming
+class Dish < ModelBase
 end
 class DishesController < InheritedResources::Base
   belongs_to :house do
@@ -101,14 +98,11 @@ class DishesController < InheritedResources::Base
   end
 end
 
-class Dishwasher
-  extend ActiveModel::Naming
+class Dishwasher < ModelBase
 end
-class Fork
-  extend ActiveModel::Naming
+class Fork < ModelBase
 end
-class Spot
-  extend ActiveModel::Naming
+class Spot < ModelBase
 end
 class SpotsController < InheritedResources::Base
   belongs_to :house do
@@ -507,7 +501,9 @@ class UrlHelpersTest < ActiveSupport::TestCase
     house = House.new
     dishwasher = Dishwasher.new
     fork = Fork.new
+    fork.stubs(:persisted?).returns(true)
     spot = Spot.new
+    spot.stubs(:persisted?).returns(true)
 
     new_spot = Spot.new
     Spot.stubs(:new).returns(new_spot)
@@ -543,7 +539,9 @@ class UrlHelpersTest < ActiveSupport::TestCase
 
   def test_url_helpers_on_polymorphic_belongs_to
     house = House.new
+    house.stubs(:persisted?).returns(true)
     bed   = Bed.new
+    bed.stubs(:persisted?).returns(true)
 
     new_bed = Bed.new
     Bed.stubs(:new).returns(new_bed)
@@ -597,7 +595,9 @@ class UrlHelpersTest < ActiveSupport::TestCase
 
   def test_url_helpers_on_polymorphic_belongs_to_using_uncountable
     sheep  = Sheep.new
+    sheep.stubs(:persisted?).returns(true)
     news = News.new
+    news.stubs(:persisted?).returns(true)
 
     new_sheep = Sheep.new
     Sheep.stubs(:new).returns(new_sheep)
@@ -684,7 +684,9 @@ class UrlHelpersTest < ActiveSupport::TestCase
 
   def test_url_helpers_on_namespaced_polymorphic_belongs_to
     house = House.new
+    house.stubs(:persisted?).returns(true)
     desk  = Desk.new
+    desk.stubs(:persisted?).returns(true)
 
     new_desk = Desk.new
     Desk.stubs(:new).returns(new_desk)
@@ -739,7 +741,9 @@ class UrlHelpersTest < ActiveSupport::TestCase
   def test_url_helpers_on_nested_polymorphic_belongs_to
     house = House.new
     table = Table.new
+    table.stubs(:persisted?).returns(true)
     dish  = Dish.new
+    dish.stubs(:persisted?).returns(true)
 
     new_dish = Dish.new
     Dish.stubs(:new).returns(new_dish)
@@ -793,7 +797,9 @@ class UrlHelpersTest < ActiveSupport::TestCase
     # This must not be usefull in singleton controllers...
     # Center.new
     house = House.new
+    house.stubs(:persisted?).returns(true)
     table = Table.new
+    table.stubs(:persisted?).returns(true)
 
     controller = CentersController.new
     controller.instance_variable_set('@parent_type', :table)
@@ -840,6 +846,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
 
   def test_url_helpers_on_optional_polymorphic_belongs_to
     bed   = Bed.new
+    bed.stubs(:persisted?).returns(true)
     new_bed = Bed.new
     Bed.stubs(:new).returns(new_bed)
     new_bed.stubs(:persisted?).returns(false)


### PR DESCRIPTION
I believe the order related problems running the tests in rails 4.2 are due to test cases modifying the controller class.  This pull request creates a different controller class per test case, although I did have to define `name` to make this work (because it appears to be hard to dynmically create controller classes with a known name at the time that inherited resources as initialized).  An alternative might have been to just modify the singleton class in the testcases, but I think that's more confusing.
