### PR TITLE
run specs on travis against all major rails versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,13 @@ rvm:
   - 2.1.5
   - 2.2.0
   - jruby-19mode # JRuby in 1.9 mode
-  - rbx-2.1.1
+  - rbx-2.2.10
 gemfile:
+  - test/gemfiles/Gemfile-Rails-3-2
+  - test/gemfiles/Gemfile-Rails-4-0
   - test/gemfiles/Gemfile-Rails-4-1
   - test/gemfiles/Gemfile-Rails-4-2
+matrix:
+  exclude:
+    - rvm: 2.2.0
+      gemfile: test/gemfiles/Gemfile-Rails-3-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.5
+  - 2.2.0
+  - jruby-19mode # JRuby in 1.9 mode
+  - rbx-2.1.1
+gemfile:
+  - test/gemfiles/Gemfile-Rails-4-1
+  - test/gemfiles/Gemfile-Rails-4-2

--- a/test/gemfiles/Gemfile-Rails-3-2
+++ b/test/gemfiles/Gemfile-Rails-3-2
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+gemspec :path => '../..'
+
+gem 'rails', '~> 3.2.0'
+gem 'strong_parameters'
+gem 'minitest', '~> 4.0'
+
+gem 'mocha'
+gem 'minitest-rg'

--- a/test/gemfiles/Gemfile-Rails-4-0
+++ b/test/gemfiles/Gemfile-Rails-4-0
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec :path => '../..'
+
+gem 'rails', '~> 4.0.0'
+gem 'minitest', '~> 4.0'
+
+gem 'mocha'
+gem 'minitest-rg'

--- a/test/gemfiles/Gemfile-Rails-4-1
+++ b/test/gemfiles/Gemfile-Rails-4-1
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :path => '../..'
 
-gem 'rails', '~> 4.2.0'
+gem 'rails', '~> 4.1.0'
 
 gem 'mocha'
 gem 'minitest-rg'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,10 +3,9 @@ require 'bundler'
 
 Bundler.setup
 
-require 'minitest'
+require 'minitest/autorun'
 require 'mocha/mini_test'
 require 'minitest/rg'
-require 'minitest/autorun'
 
 ENV["RAILS_ENV"] = "test"
 RAILS_ROOT = "anywhere"


### PR DESCRIPTION
Here is a travis.yml and associated files to run the tests for rails 3.2, rails 4.0, rails 4.1 and rails 4.2.  These should all pass.  I also enabled a bunch of ruby versions.  Note that rubinious appears to have a bug above version 2.2.10 that breaks inherited resources specs and behavior (for details see the bug I've created at https://github.com/rubinius/rubinius/issues/3272).
