### PR TITLE
Removed HttpCacheResponder, closes #342

### DIFF
--- a/lib/inherited_resources/responder.rb
+++ b/lib/inherited_resources/responder.rb
@@ -1,6 +1,5 @@
 module InheritedResources
   class Responder < ActionController::Responder
     include Responders::FlashResponder
-    include Responders::HttpCacheResponder
   end
 end


### PR DESCRIPTION
This responder hit us @bitcrowd and @brendon by surprise. It only adds 
caching if used as an API endpoint, not when serving html pages.

As discussed in the ticket #342 we are now removing it in the `InheritedResources::Responder`
