### PR TITLE
use super for permitted_params

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -340,6 +340,7 @@ module InheritedResources
       #    end
       #
       def permitted_params
+        return super if defined?(super)
         return nil  unless respond_to?(resource_params_method_name, true)
         {resource_request_name => send(resource_params_method_name)}
       rescue ActionController::ParameterMissing


### PR DESCRIPTION
I have a class with inherit_resources

``` ruby
class Admin::PostsController < Admin::BaseController
  inherit_resources
  …
end
```

And permitted_params defined here in protected

``` ruby
class Admin::BaseController < ActionController::Base
  …
  protected
  …
  def permitted_params
    params.permit!
  end
end
```

It works on inherit_resources version 1.4.1
But after upgrade to 1.6.0 my test had broken.
If define permitted_params in Admin::PostsController in protected or in public — it works
I found way to fix that, and it works.
