### PR TITLE
Version bumps for Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.5
-  - 2.2.0
-  - jruby-19mode # JRuby in 1.9 mode
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
+  - jruby-9.0.5.0
   - rbx-2.2.10
 gemfile:
   - test/gemfiles/Gemfile-Rails-3-2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+# Version 1.7.0
+
+* Support Rails 5
+* Remove support for Ruby < 2.1
+* Fix URL helpers on mountable engines
+
 # Version 1.6.0
 
 * Support Rails 4.2.

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
   s.files         = Dir["app/**/*", "lib/**/*", "README.md", "MIT-LICENSE"]
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = '>= 2.1'
+
   s.add_dependency("responders")
   s.add_dependency("actionpack", ">= 3.2", "< 5.1")
   s.add_dependency("railties", ">= 3.2", "< 5.1")

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("responders")
-  s.add_dependency("actionpack", ">= 3.2", "< 5")
-  s.add_dependency("railties", ">= 3.2", "< 5")
+  s.add_dependency("actionpack", ">= 3.2", "< 5.1")
+  s.add_dependency("railties", ">= 3.2", "< 5.1")
   s.add_dependency("has_scope",  "~> 0.6.0.rc")
 end

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.add_dependency("responders")
   s.add_dependency("actionpack", ">= 3.2", "< 5.1")
   s.add_dependency("railties", ">= 3.2", "< 5.1")
-  s.add_dependency("has_scope",  "~> 0.6.0.rc")
+  s.add_dependency("has_scope",  "~> 0.6")
 end


### PR DESCRIPTION
I know that inherited_resources is deprecated and not maintained, but please @rafaelfranca help as to keep @activeadmin alive. We depending on inherited_resources. ActiveAdmin works with Rails 5 and this inherited_resources change.
