### PR TITLE
fix rescue from load error in engine loading

### DIFF
--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -368,7 +368,7 @@ module InheritedResources
         namespaces.delete_if do |namespace|
           begin
             "#{namespace}/engine".camelize.constantize.isolated?
-          rescue
+          rescue LoadError, NoMethodError
             false
           end
         end


### PR DESCRIPTION
There happens a strange error when Rails 5 is in use and a engine is used and a namespace which has no engine is used.

All this happens if you use Rails5, ActiveAdmin and the Knock or MailyHerald::Webui gem together.

Here is a App to reproduce the error: https://github.com/brentmulligan/aa-knock-issue
Stacktrace for the error: https://gist.github.com/brentmulligan/ad2ff32b27c3a20b0c9db8e5acd90ca7
(THX to @brentmulligan)

After some debugging I found out that [this `rescue`](https://github.com/josevalim/inherited_resources/blob/master/lib/inherited_resources/class_methods.rb#L371) don't capture the LoadError.

related to: https://github.com/activeadmin/activeadmin/issues/4532
