### PR TITLE
Fix rescue from LoadError in engine loading

### DIFF
--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -368,7 +368,7 @@ module InheritedResources
         namespaces.delete_if do |namespace|
           begin
             "#{namespace}/engine".camelize.constantize.isolated?
-          rescue
+          rescue StandardError, LoadError
             false
           end
         end

--- a/test/autoload/engine.rb
+++ b/test/autoload/engine.rb
@@ -1,0 +1,3 @@
+module MyTestNamespace
+  class Engine; end
+end

--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -62,6 +62,8 @@ module MyNamespace
   class PeopleController < InheritedResources::Base; end
 end
 
+module EmptyNamespace; end
+
 class ActionsClassMethodTest < ActionController::TestCase
   tests BooksController
 
@@ -204,5 +206,15 @@ class MountableEngineTest < ActiveSupport::TestCase
 
   def test_route_prefix_present_when_parent_module_is_not_a_engine
     assert_equal 'my_namespace', MyNamespace::PeopleController.send(:resources_configuration)[:self][:route_prefix]
+  end
+end
+
+class EngineLoadErrorTest < ActiveSupport::TestCase
+  def test_does_not_crash_on_engine_load_error
+    ActiveSupport::Dependencies.autoload_paths << 'test/autoload'
+
+    EmptyNamespace.class_eval <<-RUBY
+      class PeopleController < InheritedResources::Base; end
+    RUBY
   end
 end


### PR DESCRIPTION
Fix for #417.

The same exact idea as in #416, but with a different set of exception types.

cc @timoschilling @brentmulligan
