### PR TITLE
Keep returning nil when the instance variable is not present

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -223,8 +223,11 @@ module InheritedResources
       # Get resource ivar based on the current resource controller.
       #
       def get_resource_ivar #:nodoc:
-        instance_variable_defined?(:"@#{resource_instance_name}") &&
+        if instance_variable_defined?(:"@#{resource_instance_name}")
           instance_variable_get("@#{resource_instance_name}")
+        else
+          nil
+        end
       end
 
       # Set resource ivar based on the current resource controller.
@@ -236,8 +239,11 @@ module InheritedResources
       # Get collection ivar based on the current resource controller.
       #
       def get_collection_ivar #:nodoc:
-        instance_variable_defined?(:"@#{resource_collection_name}") &&
+        if instance_variable_defined?(:"@#{resource_collection_name}")
           instance_variable_get("@#{resource_collection_name}")
+        else
+          nil
+        end
       end
 
       # Set collection ivar based on the current resource controller.

--- a/lib/inherited_resources/belongs_to_helpers.rb
+++ b/lib/inherited_resources/belongs_to_helpers.rb
@@ -75,12 +75,12 @@ module InheritedResources
           set_parent_instance(parent_config, chain)
       end
 
-      def get_parent_ivar(instance_name)
+      def get_parent_ivar(instance_name) #:nodoc:
         instance_variable_defined?(:"@#{instance_name}") &&
           instance_variable_get("@#{instance_name}")
       end
 
-      def set_parent_instance(parent_config, chain)
+      def set_parent_instance(parent_config, chain) #:nodoc:
         if parent_config[:singleton]
           parent = if chain
             chain.send(parent_config[:instance_name])


### PR DESCRIPTION
In fccf98f there were a subtle behavior change that was returning false when the instance variable was not defined.