### PR TITLE
Do not use local jump in the on_load hook

### DIFF
--- a/lib/inherited_resources.rb
+++ b/lib/inherited_resources.rb
@@ -27,14 +27,14 @@ end
 
 ActiveSupport.on_load(:action_controller) do
   # We can remove this check and change to `on_load(:action_controller_base)` in Rails 5.2.
-  break unless self == ActionController::Base
-
-  # If you cannot inherit from InheritedResources::Base you can call
-  # inherit_resources in your controller to have all the required modules and
-  # funcionality included.
-  def self.inherit_resources
-    InheritedResources::Base.inherit_resources(self)
-    initialize_resources_class_accessors!
-    create_resources_url_helpers!
+  if self == ActionController::Base
+    # If you cannot inherit from InheritedResources::Base you can call
+    # inherit_resources in your controller to have all the required modules and
+    # funcionality included.
+    def self.inherit_resources
+      InheritedResources::Base.inherit_resources(self)
+      initialize_resources_class_accessors!
+      create_resources_url_helpers!
+    end
   end
 end


### PR DESCRIPTION
Some versions of Ruby will fail with a LocalJumpError.

Fixes #428