### PR TITLE
Fix deprecation of interpolation_options in responders

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -149,7 +149,7 @@ module InheritedResources
       # Overwrite this method to provide other interpolation options when
       # the flash message is going to be set.
       #
-      # def interpolation_options
+      # def flash_interpolation_options
       #    { }
       # end
 


### PR DESCRIPTION
The `interpolation_options` method is deprecated. Update to the suggested `flash_interpolation_options` method. This is only a documentation change to the suggested override.