### PR TITLE
Support Rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,12 @@ gemfile:
   - test/gemfiles/Gemfile-Rails-4-1
   - test/gemfiles/Gemfile-Rails-4-2
   - test/gemfiles/Gemfile-Rails-5-0
+  - test/gemfiles/Gemfile-Rails-5-1
 matrix:
   exclude:
     - rvm: 2.1.9
       gemfile: test/gemfiles/Gemfile-Rails-5-0
+    - rvm: 2.1.9
+      gemfile: test/gemfiles/Gemfile-Rails-5-1
   allow_failures:
     - rvm: rbx-2.2.10

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# Version 1.7.2
+
+* Support Rails 5.1
+
 # Version 1.7.1
 
 * Fix regression with `get_resource_ivar` that was returning `false`

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1'
 
   s.add_dependency("responders")
-  s.add_dependency("actionpack", ">= 3.2", "< 5.2")
-  s.add_dependency("railties", ">= 3.2", "< 5.2")
+  s.add_dependency("actionpack", ">= 3.2", "< 5.2.x")
+  s.add_dependency("railties", ">= 3.2", "< 5.2.x")
   s.add_dependency("has_scope",  "~> 0.6")
 end

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1'
 
   s.add_dependency("responders")
-  s.add_dependency("actionpack", ">= 3.2", "< 5.1")
-  s.add_dependency("railties", ">= 3.2", "< 5.1")
+  s.add_dependency("actionpack", ">= 3.2", "< 5.2")
+  s.add_dependency("railties", ">= 3.2", "< 5.2")
   s.add_dependency("has_scope",  "~> 0.6")
 end

--- a/test/aliases_test.rb
+++ b/test/aliases_test.rb
@@ -1,5 +1,9 @@
 require File.expand_path('test_helper', File.dirname(__FILE__))
 
+def plain_text
+  ActionPack::VERSION::MAJOR >= 5 ? :plain : :text
+end
+
 class Student
   extend ActiveModel::Naming
 end
@@ -14,7 +18,7 @@ class StudentsController < ApplicationController
 
   def edit
     edit! do |format|
-      format.xml { render :text => 'Render XML' }
+      format.xml { render plain_text => 'Render XML' }
     end
   end
 
@@ -24,17 +28,17 @@ class StudentsController < ApplicationController
   end
 
   create!(:location => "http://test.host/") do |success, failure|
-    success.html { render :text => "I won't redirect!" }
-    failure.xml { render :text => "I shouldn't be rendered" }
+    success.html { render plain_text => "I won't redirect!" }
+    failure.xml { render plain_text => "I shouldn't be rendered" }
   end
 
   update! do |success, failure|
     success.html { redirect_to(resource_url) }
-    failure.html { render :text => "I won't render!" }
+    failure.html { render plain_text => "I won't render!" }
   end
 
   destroy! do |format|
-    format.html { render :text => "Destroyed!" }
+    format.html { render plain_text => "Destroyed!" }
   end
 end
 

--- a/test/aliases_test.rb
+++ b/test/aliases_test.rb
@@ -57,7 +57,7 @@ class AliasesTest < ActionController::TestCase
 
   def test_expose_the_requested_user_on_edit
     Student.expects(:find).with('42').returns(mock_student)
-    get :edit, :id => '42'
+    get :edit, request_params(:id => '42')
     assert_equal mock_student, assigns(:student)
     assert_response :success
   end
@@ -113,7 +113,7 @@ class AliasesTest < ActionController::TestCase
   def test_dumb_responder_quietly_receives_everything_on_success
     Student.stubs(:find).returns(mock_student(:update_attributes => true))
     @controller.stubs(:resource_url).returns('http://test.host/')
-    put :update, :id => '42', :student => {:these => 'params'}
+    put :update, request_params(:id => '42', :student => {:these => 'params'})
     assert_equal mock_student, assigns(:student)
   end
 
@@ -138,9 +138,8 @@ class AliasesTest < ActionController::TestCase
       @mock_student ||= begin
         student = mock(expectations.except(:errors))
         student.stubs(:class).returns(Student)
-        student.stubs(:errors).returns(expectations.fetch(:errors, {})) 
+        student.stubs(:errors).returns(expectations.fetch(:errors, {}))
         student
       end
     end
 end
-

--- a/test/association_chain_test.rb
+++ b/test/association_chain_test.rb
@@ -52,7 +52,7 @@ class BeginOfAssociationChainTest < ActionController::TestCase
   def test_begin_of_association_chain_is_called_on_show
     @controller.current_user.expects(:pets).returns(Pet)
     Pet.expects(:find).with('47').returns(mock_pet)
-    get :show, :id => '47'
+    get :show, request_params(:id => '47')
     assert_response :success
     assert_equal 'Show HTML', @response.body.strip
   end
@@ -103,14 +103,14 @@ class AssociationChainTest < ActionController::TestCase
     mock_pet.expects(:puppets).returns(Puppet)
     Puppet.expects(:find).with('42').returns(mock_puppet)
     mock_puppet.expects(:destroy)
-    delete :destroy, :id => '42', :pet_id => '37'
+    delete :destroy, request_params(:id => '42', :pet_id => '37')
     assert_equal [mock_pet], @controller.send(:association_chain)
   end
 
   def test_parent_is_added_to_association_chain_if_not_available
     Puppet.expects(:find).with('42').returns(mock_puppet)
     mock_puppet.expects(:destroy)
-    delete :destroy, :id => '42'
+    delete :destroy, request_params(:id => '42')
     assert_equal [], @controller.send(:association_chain)
   end
 

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -36,15 +36,16 @@ module UserTestHelper
   protected
 
   def new_request
-    ActionPack::VERSION::MAJOR >= 5 ? # see Rails 3806eb7
-      ActionController::TestRequest.new({}, ActionController::TestSession.new) :
-      ActionController::TestRequest.new
+    return ActionController::TestRequest.new if ActionPack::VERSION::MAJOR < 5
+    if ActionPack::VERSION::MAJOR == 5 && ActionPack::VERSION::MINOR < 1
+      ActionController::TestRequest.new({}, ActionController::TestSession.new)
+    else
+      ActionController::TestRequest.create(UsersController)
+    end
   end
 
   def new_response
-    ActionPack::VERSION::MAJOR >= 5 ? # see Rails e26d11c
-      ActionDispatch::TestResponse.new :
-      ActionController::TestResponse.new
+    ActionPack::VERSION::MAJOR < 5 ? ActionController::TestResponse.new : ActionDispatch::TestResponse.create
   end
 
   def mock_user(expectations={})

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -106,7 +106,7 @@ class ShowActionBaseTest < ActionController::TestCase
 
   def test_expose_the_requested_user
     User.expects(:find).with('42').returns(mock_user)
-    get :show, :id => '42'
+    get :show, request_params(:id => '42')
     assert_equal mock_user, assigns(:user)
   end
 
@@ -122,7 +122,7 @@ class ShowActionBaseTest < ActionController::TestCase
     User.expects(:find).with('42').returns(mock_user)
     mock_user.expects(:to_xml).returns("Generated XML")
 
-    get :show, :id => '42'
+    get :show, request_params(:id => '42')
     assert_response :success
     assert_equal 'Generated XML', @response.body
   end
@@ -160,7 +160,7 @@ class EditActionBaseTest < ActionController::TestCase
 
   def test_expose_the_requested_user
     User.expects(:find).with('42').returns(mock_user)
-    get :edit, :id => '42'
+    get :edit, request_params(:id => '42')
     assert_response :success
     assert_equal mock_user, assigns(:user)
   end
@@ -178,21 +178,21 @@ class CreateActionBaseTest < ActionController::TestCase
 
   def test_expose_a_newly_create_user_when_saved_with_success
     User.expects(:new).with({'these' => 'params'}).returns(mock_user(:save => true))
-    post :create, :user => {:these => 'params'}
+    post :create, request_params(:user => {:these => 'params'})
     assert_equal mock_user, assigns(:user)
   end
 
   def test_expose_a_newly_create_user_when_saved_with_success_and_role_setted
     @controller.class.send(:with_role, :admin)
     User.expects(:new).with({'these' => 'params'}, {:as => :admin}).returns(mock_user(:save => true))
-    post :create, :user => {:these => 'params'}
+    post :create, request_params(:user => {:these => 'params'})
     assert_equal mock_user, assigns(:user)
   end
 
   def test_expose_a_newly_create_user_when_saved_with_success_and_without_protection_setted
     @controller.class.send(:without_protection, true)
     User.expects(:new).with({'these' => 'params'}, {:without_protection => true}).returns(mock_user(:save => true))
-    post :create, :user => {:these => 'params'}
+    post :create, request_params(:user => {:these => 'params'})
     assert_equal mock_user, assigns(:user)
   end
 
@@ -235,7 +235,7 @@ class UpdateActionBaseTest < ActionController::TestCase
   def test_update_the_requested_object
     User.expects(:find).with('42').returns(mock_user)
     mock_user.expects(:update_attributes).with({'these' => 'params'}).returns(true)
-    put :update, :id => '42', :user => {:these => 'params'}
+    put :update, request_params(:id => '42', :user => {:these => 'params'})
     assert_equal mock_user, assigns(:user)
   end
 
@@ -243,7 +243,7 @@ class UpdateActionBaseTest < ActionController::TestCase
     @controller.class.send(:with_role, :admin)
     User.expects(:find).with('42').returns(mock_user)
     mock_user.expects(:update_attributes).with({'these' => 'params'}, {:as => :admin}).returns(true)
-    put :update, :id => '42', :user => {:these => 'params'}
+    put :update, request_params(:id => '42', :user => {:these => 'params'})
     assert_equal mock_user, assigns(:user)
   end
 
@@ -251,7 +251,7 @@ class UpdateActionBaseTest < ActionController::TestCase
     @controller.class.send(:without_protection, true)
     User.expects(:find).with('42').returns(mock_user)
     mock_user.expects(:update_attributes).with({'these' => 'params'}, {:without_protection => true}).returns(true)
-    put :update, :id => '42', :user => {:these => 'params'}
+    put :update, request_params(:id => '42', :user => {:these => 'params'})
     assert_equal mock_user, assigns(:user)
   end
 
@@ -302,7 +302,7 @@ class DestroyActionBaseTest < ActionController::TestCase
   def test_the_requested_user_is_destroyed
     User.expects(:find).with('42').returns(mock_user)
     mock_user.expects(:destroy).returns(true)
-    delete :destroy, :id => '42'
+    delete :destroy, request_params(:id => '42')
     assert_equal mock_user, assigns(:user)
   end
 

--- a/test/belongs_to_test.rb
+++ b/test/belongs_to_test.rb
@@ -30,28 +30,28 @@ class BelongsToTest < ActionController::TestCase
 
   def test_expose_all_comments_as_instance_variable_on_index
     Comment.expects(:scoped).returns([mock_comment])
-    get :index, :post_id => '37'
+    get :index, request_params(:post_id => '37')
     assert_equal mock_post, assigns(:post)
     assert_equal [mock_comment], assigns(:comments)
   end
 
   def test_expose_the_requested_comment_on_show
     Comment.expects(:find).with('42').returns(mock_comment)
-    get :show, :id => '42', :post_id => '37'
+    get :show, request_params(:id => '42', :post_id => '37')
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
   end
 
   def test_expose_a_new_comment_on_new
     Comment.expects(:build).returns(mock_comment)
-    get :new, :post_id => '37'
+    get :new, request_params(:post_id => '37')
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
   end
 
   def test_expose_the_requested_comment_on_edit
     Comment.expects(:find).with('42').returns(mock_comment)
-    get :edit, :id => '42', :post_id => '37'
+    get :edit, request_params(:id => '42', :post_id => '37')
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
   end
@@ -60,13 +60,13 @@ class BelongsToTest < ActionController::TestCase
     @controller.class.send(:actions, :all, :except => [:show, :index])
     @controller.expects(:parent_url).returns('http://test.host/')
     Comment.expects(:build).with({'these' => 'params'}).returns(mock_comment(:save => true))
-    post :create, :post_id => '37', :comment => {:these => 'params'}
+    post :create, request_params(:post_id => '37', :comment => {:these => 'params'})
     assert_redirected_to 'http://test.host/'
   end
 
   def test_expose_a_newly_create_comment_on_create
     Comment.expects(:build).with({'these' => 'params'}).returns(mock_comment(:save => true))
-    post :create, :post_id => '37', :comment => {:these => 'params'}
+    post :create, request_params(:post_id => '37', :comment => {:these => 'params'})
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
   end
@@ -75,14 +75,14 @@ class BelongsToTest < ActionController::TestCase
     @controller.class.send(:actions, :all, :except => [:show, :index])
     Comment.stubs(:find).returns(mock_comment(:update_attributes => true))
     @controller.expects(:parent_url).returns('http://test.host/')
-    put :update, :id => '42', :post_id => '37', :comment => {:these => 'params'}
+    put :update, request_params(:id => '42', :post_id => '37', :comment => {:these => 'params'})
     assert_redirected_to 'http://test.host/'
   end
 
   def test_update_the_requested_object_on_update
     Comment.expects(:find).with('42').returns(mock_comment)
     mock_comment.expects(:update_attributes).with({'these' => 'params'}).returns(true)
-    put :update, :id => '42', :post_id => '37', :comment => {:these => 'params'}
+    put :update, request_params(:id => '42', :post_id => '37', :comment => {:these => 'params'})
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
   end
@@ -92,14 +92,14 @@ class BelongsToTest < ActionController::TestCase
     Comment.expects(:find).with('42').returns(mock_comment)
     mock_comment.expects(:destroy)
     @controller.expects(:parent_url).returns('http://test.host/')
-    delete :destroy, :id => '42', :post_id => '37'
+    delete :destroy, request_params(:id => '42', :post_id => '37')
     assert_redirected_to 'http://test.host/'
   end
 
   def test_the_requested_comment_is_destroyed_on_destroy
     Comment.expects(:find).with('42').returns(mock_comment)
     mock_comment.expects(:destroy)
-    delete :destroy, :id => '42', :post_id => '37'
+    delete :destroy, request_params(:id => '42', :post_id => '37')
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
   end
@@ -112,7 +112,7 @@ class BelongsToTest < ActionController::TestCase
     mock_post.stubs(:class).returns(Post)
 
     Comment.expects(:scoped).returns([mock_comment])
-    get :index, :post_id => '37'
+    get :index, request_params(:post_id => '37')
 
     assert helper_methods.include?('parent?')
     assert @controller.send(:parent?)

--- a/test/belongs_to_with_shallow_test.rb
+++ b/test/belongs_to_with_shallow_test.rb
@@ -25,35 +25,35 @@ class BelongsToWithShallowTest < ActionController::TestCase
 
   def test_expose_all_tags_as_instance_variable_on_index
     Tag.expects(:scoped).returns([mock_tag])
-    get :index, :post_id => 'thirty_seven'
+    get :index, request_params(:post_id => 'thirty_seven')
     assert_equal mock_post, assigns(:post)
     assert_equal [mock_tag], assigns(:tags)
   end
 
   def test_expose_a_new_tag_on_new
     Tag.expects(:build).returns(mock_tag)
-    get :new, :post_id => 'thirty_seven'
+    get :new, request_params(:post_id => 'thirty_seven')
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)
   end
 
   def test_expose_a_newly_create_tag_on_create
     Tag.expects(:build).with({'these' => 'params'}).returns(mock_tag(:save => true))
-    post :create, :post_id => 'thirty_seven', :tag => {:these => 'params'}
+    post :create, request_params(:post_id => 'thirty_seven', :tag => {:these => 'params'})
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)
   end
 
   def test_expose_the_requested_tag_on_show
     should_find_parents
-    get :show, :id => '42'
+    get :show, request_params(:id => '42')
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)
   end
 
   def test_expose_the_requested_tag_on_edit
     should_find_parents
-    get :edit, :id => '42'
+    get :edit, request_params(:id => '42')
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)
   end
@@ -61,7 +61,7 @@ class BelongsToWithShallowTest < ActionController::TestCase
   def test_update_the_requested_object_on_update
     should_find_parents
     mock_tag.expects(:update_attributes).with({'these' => 'params'}).returns(true)
-    put :update, :id => '42', :tag => {:these => 'params'}
+    put :update, request_params(:id => '42', :tag => {:these => 'params'})
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)
   end
@@ -69,7 +69,7 @@ class BelongsToWithShallowTest < ActionController::TestCase
   def test_the_requested_tag_is_destroyed_on_destroy
     should_find_parents
     mock_tag.expects(:destroy)
-    delete :destroy, :id => '42', :post_id => '37'
+    delete :destroy, request_params(:id => '42', :post_id => '37')
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)
   end

--- a/test/customized_base_test.rb
+++ b/test/customized_base_test.rb
@@ -44,15 +44,16 @@ module CarTestHelper
 
   protected
     def new_request
-      ActionPack::VERSION::MAJOR >= 5 ? # see Rails 3806eb7
-        ActionController::TestRequest.new({}, ActionController::TestSession.new) :
-        ActionController::TestRequest.new
+      return ActionController::TestRequest.new if ActionPack::VERSION::MAJOR < 5
+      if ActionPack::VERSION::MAJOR == 5 && ActionPack::VERSION::MINOR < 1
+        ActionController::TestRequest.new({}, ActionController::TestSession.new)
+      else
+        ActionController::TestRequest.create(CarsController)
+      end
     end
 
     def new_response
-      ActionPack::VERSION::MAJOR >= 5 ? # see Rails e26d11c
-        ActionDispatch::TestResponse.new :
-        ActionController::TestResponse.new
+      ActionPack::VERSION::MAJOR < 5 ? ActionController::TestResponse.new : ActionDispatch::TestResponse.create
     end
 
     def mock_car(expectations={})

--- a/test/customized_base_test.rb
+++ b/test/customized_base_test.rb
@@ -80,7 +80,7 @@ class ShowActionCustomizedBaseTest < ActionController::TestCase
 
   def test_expose_the_requested_user
     Car.expects(:get).with('42').returns(mock_car)
-    get :show, :id => '42'
+    get :show, request_params(:id => '42')
     assert_equal mock_car, assigns(:car)
   end
 end
@@ -100,7 +100,7 @@ class EditActionCustomizedBaseTest < ActionController::TestCase
 
   def test_expose_the_requested_user
     Car.expects(:get).with('42').returns(mock_car)
-    get :edit, :id => '42'
+    get :edit, request_params(:id => '42')
     assert_response :success
     assert_equal mock_car, assigns(:car)
   end
@@ -111,7 +111,7 @@ class CreateActionCustomizedBaseTest < ActionController::TestCase
 
   def test_expose_a_newly_create_user_when_saved_with_success
     Car.expects(:create_new).with({'these' => 'params'}).returns(mock_car(:save_successfully => true))
-    post :create, :car => {:these => 'params'}
+    post :create, request_params(:car => {:these => 'params'})
     assert_equal mock_car, assigns(:car)
   end
 
@@ -136,7 +136,7 @@ class UpdateActionCustomizedBaseTest < ActionController::TestCase
   def test_update_the_requested_object
     Car.expects(:get).with('42').returns(mock_car)
     mock_car.expects(:update_successfully).with({'these' => 'params'}).returns(true)
-    put :update, :id => '42', :car => {:these => 'params'}
+    put :update, request_params(:id => '42', :car => {:these => 'params'})
     assert_equal mock_car, assigns(:car)
   end
 
@@ -161,7 +161,7 @@ class DestroyActionCustomizedBaseTest < ActionController::TestCase
   def test_the_requested_user_is_destroyed
     Car.expects(:get).with('42').returns(mock_car)
     mock_car.expects(:destroy_successfully)
-    delete :destroy, :id => '42'
+    delete :destroy, request_params(:id => '42')
     assert_equal mock_car, assigns(:car)
   end
 
@@ -177,4 +177,3 @@ class DestroyActionCustomizedBaseTest < ActionController::TestCase
     assert_equal flash[:alert], 'Car could not be destroyed.'
   end
 end
-

--- a/test/customized_belongs_to_test.rb
+++ b/test/customized_belongs_to_test.rb
@@ -23,43 +23,43 @@ class CustomizedBelongsToTest < ActionController::TestCase
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_index
     Professor.stubs(:scoped).returns([mock_professor])
-    get :index, :school_title => 'nice'
+    get :index, request_params(:school_title => 'nice')
     assert_equal mock_school, assigns(:great_school)
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_show
     Professor.stubs(:find).returns(mock_professor)
-    get :show, :school_title => 'nice'
+    get :show, request_params(:school_title => 'nice')
     assert_equal mock_school, assigns(:great_school)
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_new
     Professor.stubs(:build).returns(mock_professor)
-    get :new, :school_title => 'nice'
+    get :new, request_params(:school_title => 'nice')
     assert_equal mock_school, assigns(:great_school)
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_edit
     Professor.stubs(:find).returns(mock_professor)
-    get :edit, :school_title => 'nice'
+    get :edit, request_params(:school_title => 'nice')
     assert_equal mock_school, assigns(:great_school)
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_create
     Professor.stubs(:build).returns(mock_professor(:save => true))
-    post :create, :school_title => 'nice'
+    post :create, request_params(:school_title => 'nice')
     assert_equal mock_school, assigns(:great_school)
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_update
     Professor.stubs(:find).returns(mock_professor(:update_attributes => true))
-    put :update, :school_title => 'nice'
+    put :update, request_params(:school_title => 'nice')
     assert_equal mock_school, assigns(:great_school)
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_destroy
     Professor.stubs(:find).returns(mock_professor(:destroy => true))
-    delete :destroy, :school_title => 'nice'
+    delete :destroy, request_params(:school_title => 'nice')
     assert_equal mock_school, assigns(:great_school)
   end
 

--- a/test/defaults_test.rb
+++ b/test/defaults_test.rb
@@ -30,7 +30,7 @@ class DefaultsTest < ActionController::TestCase
 
   def test_expose_the_requested_painter_on_show
     Malarz.expects(:find_by_slug).with('forty_two').returns(mock_painter)
-    get :show, :id => 'forty_two'
+    get :show, request_params(:id => 'forty_two')
     assert_equal mock_painter, assigns(:malarz)
   end
 
@@ -42,28 +42,28 @@ class DefaultsTest < ActionController::TestCase
 
   def test_expose_the_requested_painter_on_edit
     Malarz.expects(:find_by_slug).with('forty_two').returns(mock_painter)
-    get :edit, :id => 'forty_two'
+    get :edit, request_params(:id => 'forty_two')
     assert_response :success
     assert_equal mock_painter, assigns(:malarz)
   end
 
   def test_expose_a_newly_create_painter_when_saved_with_success
     Malarz.expects(:new).with({'these' => 'params'}).returns(mock_painter(:save => true))
-    post :create, :malarz => {:these => 'params'}
+    post :create, request_params(:malarz => {:these => 'params'})
     assert_equal mock_painter, assigns(:malarz)
   end
 
   def test_update_the_requested_object
     Malarz.expects(:find_by_slug).with('forty_two').returns(mock_painter)
     mock_painter.expects(:update_attributes).with({'these' => 'params'}).returns(true)
-    put :update, :id => 'forty_two', :malarz => {:these => 'params'}
+    put :update, request_params(:id => 'forty_two', :malarz => {:these => 'params'})
     assert_equal mock_painter, assigns(:malarz)
   end
 
   def test_the_requested_painter_is_destroyed
     Malarz.expects(:find_by_slug).with('forty_two').returns(mock_painter)
     mock_painter.expects(:destroy)
-    delete :destroy, :id => 'forty_two'
+    delete :destroy, request_params(:id => 'forty_two')
     assert_equal mock_painter, assigns(:malarz)
   end
 
@@ -97,7 +97,7 @@ class DefaultsNamespaceTest < ActionController::TestCase
 
   def test_expose_the_requested_painter_on_show
     Professor.expects(:find_by_slug).with('forty_two').returns(mock_professor)
-    get :show, :id => 'forty_two'
+    get :show, request_params(:id => 'forty_two')
     assert_equal mock_professor, assigns(:professor)
   end
 
@@ -109,28 +109,28 @@ class DefaultsNamespaceTest < ActionController::TestCase
 
   def test_expose_the_requested_painter_on_edit
     Professor.expects(:find_by_slug).with('forty_two').returns(mock_professor)
-    get :edit, :id => 'forty_two'
+    get :edit, request_params(:id => 'forty_two')
     assert_response :success
     assert_equal mock_professor, assigns(:professor)
   end
 
   def test_expose_a_newly_create_professor_when_saved_with_success
     Professor.expects(:new).with({'these' => 'params'}).returns(mock_professor(:save => true))
-    post :create, :professor => {:these => 'params'}
+    post :create, request_params(:professor => {:these => 'params'})
     assert_equal mock_professor, assigns(:professor)
   end
 
   def test_update_the_professor
     Professor.expects(:find_by_slug).with('forty_two').returns(mock_professor)
     mock_professor.expects(:update_attributes).with({'these' => 'params'}).returns(true)
-    put :update, :id => 'forty_two', :professor => {:these => 'params'}
+    put :update, request_params(:id => 'forty_two', :professor => {:these => 'params'})
     assert_equal mock_professor, assigns(:professor)
   end
 
   def test_the_requested_painter_is_destroyed
     Professor.expects(:find_by_slug).with('forty_two').returns(mock_professor)
     mock_professor.expects(:destroy)
-    delete :destroy, :id => 'forty_two'
+    delete :destroy, request_params(:id => 'forty_two')
     assert_equal mock_professor, assigns(:professor)
   end
 

--- a/test/gemfiles/Gemfile-Rails-5-1
+++ b/test/gemfiles/Gemfile-Rails-5-1
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec :path => '../..'
 
-gem 'rails', '~> 5.1'
+gem 'rails', '~> 5.1.0'
 
 gem 'mocha'
 gem 'minitest-rg'

--- a/test/multiple_nested_optional_belongs_to_test.rb
+++ b/test/multiple_nested_optional_belongs_to_test.rb
@@ -25,7 +25,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Student.expects(:find).with('37').returns(mock_student)
 		mock_student.expects(:projects).returns(Project)
 		Project.expects(:scoped).returns([mock_project])
-		get :index, :student_id => '37'
+		get :index, request_params(:student_id => '37')
 		assert_equal mock_student, assigns(:student)
 		assert_equal [mock_project], assigns(:projects)
 	end
@@ -34,7 +34,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Manager.expects(:find).with('38').returns(mock_manager)
 		mock_manager.expects(:projects).returns(Project)
 		Project.expects(:scoped).returns([mock_project])
-		get :index, :manager_id => '38'
+		get :index, request_params(:manager_id => '38')
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal [mock_project], assigns(:projects)
 	end
@@ -43,7 +43,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Employee.expects(:find).with('666').returns(mock_employee)
 		mock_employee.expects(:projects).returns(Project)
 		Project.expects(:scoped).returns([mock_project])
-		get :index, :employee_id => '666'
+		get :index, request_params(:employee_id => '666')
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal [mock_project], assigns(:projects)
 	end
@@ -54,7 +54,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Employee.expects(:find).with('42').returns(mock_employee)
 		mock_employee.expects(:projects).returns(Project)
 		Project.expects(:scoped).returns([mock_project])
-		get :index, :manager_id => '37', :employee_id => '42'
+		get :index, request_params(:manager_id => '37', :employee_id => '42')
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal [mock_project], assigns(:projects)
@@ -71,7 +71,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Student.expects(:find).with('37').returns(mock_student)
 		mock_student.expects(:projects).returns(Project)
 		Project.expects(:find).with('42').returns(mock_project)
-		get :show, :id => '42', :student_id => '37'
+		get :show, request_params(:id => '42', :student_id => '37')
 		assert_equal mock_student, assigns(:student)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -80,7 +80,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Manager.expects(:find).with('37').returns(mock_manager)
 		mock_manager.expects(:projects).returns(Project)
 		Project.expects(:find).with('42').returns(mock_project)
-		get :show, :id => '42', :manager_id => '37'
+		get :show, request_params(:id => '42', :manager_id => '37')
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -89,7 +89,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Employee.expects(:find).with('37').returns(mock_employee)
 		mock_employee.expects(:projects).returns(Project)
 		Project.expects(:find).with('42').returns(mock_project)
-		get :show, :id => '42', :employee_id => '37'
+		get :show, request_params(:id => '42', :employee_id => '37')
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -100,7 +100,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Employee.expects(:find).with('42').returns(mock_employee)
 		mock_employee.expects(:projects).returns(Project)
 		Project.expects(:find).with('13').returns(mock_project)
-		get :show, :id => '13', :manager_id => '37', :employee_id => '42'
+		get :show, request_params(:id => '13', :manager_id => '37', :employee_id => '42')
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal mock_project, assigns(:project)
@@ -108,7 +108,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 
 	def test_expose_the_requested_project_without_parents
 		Project.expects(:find).with('13').returns(mock_project)
-		get :show, :id => '13'
+		get :show, request_params(:id => '13')
 		assert_equal mock_project, assigns(:project)
 	end
 
@@ -117,7 +117,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Student.expects(:find).with('37').returns(mock_student)
 		mock_student.expects(:projects).returns(Project)
 		Project.expects(:build).returns(mock_project)
-		get :new, :student_id => '37'
+		get :new, request_params(:student_id => '37')
 		assert_equal mock_student, assigns(:student)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -126,7 +126,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Manager.expects(:find).with('37').returns(mock_manager)
 		mock_manager.expects(:projects).returns(Project)
 		Project.expects(:build).returns(mock_project)
-		get :new, :manager_id => '37'
+		get :new, request_params(:manager_id => '37')
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -135,7 +135,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Employee.expects(:find).with('37').returns(mock_employee)
 		mock_employee.expects(:projects).returns(Project)
 		Project.expects(:build).returns(mock_project)
-		get :new, :employee_id => '37'
+		get :new, request_params(:employee_id => '37')
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -146,7 +146,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Employee.expects(:find).with('42').returns(mock_employee)
 		mock_employee.expects(:projects).returns(Project)
 		Project.expects(:build).returns(mock_project)
-		get :new, :manager_id => '37', :employee_id => '42'
+		get :new, request_params(:manager_id => '37', :employee_id => '42')
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal mock_project, assigns(:project)
@@ -163,7 +163,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Student.expects(:find).with('37').returns(mock_student)
 		mock_student.expects(:projects).returns(Project)
 		Project.expects(:find).with('42').returns(mock_project)
-		get :edit, :id => '42', :student_id => '37'
+		get :edit, request_params(:id => '42', :student_id => '37')
 		assert_equal mock_student, assigns(:student)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -172,7 +172,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Manager.expects(:find).with('37').returns(mock_manager)
 		mock_manager.expects(:projects).returns(Project)
 		Project.expects(:find).with('42').returns(mock_project)
-		get :edit, :id => '42', :manager_id => '37'
+		get :edit, request_params(:id => '42', :manager_id => '37')
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -181,7 +181,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Employee.expects(:find).with('37').returns(mock_employee)
 		mock_employee.expects(:projects).returns(Project)
 		Project.expects(:find).with('42').returns(mock_project)
-		get :edit, :id => '42', :employee_id => '37'
+		get :edit, request_params(:id => '42', :employee_id => '37')
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -192,7 +192,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Employee.expects(:find).with('42').returns(mock_employee)
 		mock_employee.expects(:projects).returns(Project)
 		Project.expects(:find).with('13').returns(mock_project)
-		get :edit, :id => '13', :manager_id => '37', :employee_id => '42'
+		get :edit, request_params(:id => '13', :manager_id => '37', :employee_id => '42')
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal mock_project, assigns(:project)
@@ -200,7 +200,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 
 	def test_expose_the_requested_project_for_edition_without_parents
 		Project.expects(:find).with('13').returns(mock_project)
-		get :edit, :id => '13'
+		get :edit, request_params(:id => '13')
 		assert_equal mock_project, assigns(:project)
 	end
 
@@ -209,7 +209,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Student.expects(:find).with('37').returns(mock_student)
 		mock_student.expects(:projects).returns(Project)
 		Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project(:save => true))
-		post :create, :student_id => '37', :project => { :these => 'params' }
+		post :create, request_params(:student_id => '37', :project => { :these => 'params' })
 		assert_equal mock_student, assigns(:student)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -218,7 +218,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Manager.expects(:find).with('37').returns(mock_manager)
 		mock_manager.expects(:projects).returns(Project)
 		Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project(:save => true))
-		post :create, :manager_id => '37', :project => { :these => 'params' }
+		post :create, request_params(:manager_id => '37', :project => { :these => 'params' })
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -227,7 +227,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Employee.expects(:find).with('37').returns(mock_employee)
 		mock_employee.expects(:projects).returns(Project)
 		Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project(:save => true))
-		post :create, :employee_id => '37', :project => { :these => 'params' }
+		post :create, request_params(:employee_id => '37', :project => { :these => 'params' })
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -238,7 +238,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Employee.expects(:find).with('42').returns(mock_employee)
 		mock_employee.expects(:projects).returns(Project)
 		Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project(:save => true))
-		post :create, :manager_id => '37', :employee_id => '42', :project => { :these => 'params' }
+		post :create, request_params(:manager_id => '37', :employee_id => '42', :project => { :these => 'params' })
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal mock_project, assigns(:project)
@@ -246,7 +246,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 
 	def test_expose_a_newly_created_project_without_parents
 		Project.expects(:new).with({ 'these' => 'params' }).returns(mock_project(:save => true))
-		post :create, :project => { :these => 'params' }
+		post :create, request_params(:project => { :these => 'params' })
 		assert_equal mock_project, assigns(:project)
 	end
 
@@ -256,7 +256,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		mock_student.expects(:projects).returns(Project)
 		Project.expects(:find).with('42').returns(mock_project)
 		mock_project.expects(:update_attributes).with({ 'these' => 'params' }).returns(true)
-		put :update, :id => '42', :student_id => '37', :project => { :these => 'params' }
+		put :update, request_params(:id => '42', :student_id => '37', :project => { :these => 'params' })
 		assert_equal mock_student, assigns(:student)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -266,7 +266,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		mock_manager.expects(:projects).returns(Project)
 		Project.expects(:find).with('42').returns(mock_project)
 		mock_project.expects(:update_attributes).with({ 'these' => 'params' }).returns(true)
-		put :update, :id => '42', :manager_id => '37', :project => { :these => 'params' }
+		put :update, request_params(:id => '42', :manager_id => '37', :project => { :these => 'params' })
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -276,7 +276,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		mock_employee.expects(:projects).returns(Project)
 		Project.expects(:find).with('42').returns(mock_project)
 		mock_project.expects(:update_attributes).with({ 'these' => 'params' }).returns(true)
-		put :update, :id => '42', :employee_id => '37', :project => { :these => 'params' }
+		put :update, request_params(:id => '42', :employee_id => '37', :project => { :these => 'params' })
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -288,7 +288,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		mock_employee.expects(:projects).returns(Project)
 		Project.expects(:find).with('42').returns(mock_project)
 		mock_project.expects(:update_attributes).with({ 'these' => 'params' }).returns(true)
-		put :update, :id => '42', :manager_id => '37', :employee_id => '13', :project => { :these => 'params' }
+		put :update, request_params(:id => '42', :manager_id => '37', :employee_id => '13', :project => { :these => 'params' })
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal mock_project, assigns(:project)
@@ -301,7 +301,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Project.expects(:find).with('42').returns(mock_project)
 		mock_project.expects(:destroy).returns(true)
 
-		delete :destroy, :id => '42', :student_id => '37'
+		delete :destroy, request_params(:id => '42', :student_id => '37')
 		assert_equal mock_student, assigns(:student)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -312,7 +312,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Project.expects(:find).with('42').returns(mock_project)
 		mock_project.expects(:destroy).returns(true)
 
-		delete :destroy, :id => '42', :manager_id => '37'
+		delete :destroy, request_params(:id => '42', :manager_id => '37')
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -323,7 +323,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Project.expects(:find).with('42').returns(mock_project)
 		mock_project.expects(:destroy).returns(true)
 
-		delete :destroy, :id => '42', :employee_id => '37'
+		delete :destroy, request_params(:id => '42', :employee_id => '37')
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal mock_project, assigns(:project)
 	end
@@ -336,7 +336,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Project.expects(:find).with('42').returns(mock_project)
 		mock_project.expects(:destroy).returns(true)
 
-		delete :destroy, :id => '42', :manager_id => '37', :employee_id => '13'
+		delete :destroy, request_params(:id => '42', :manager_id => '37', :employee_id => '13')
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_employee, assigns(:employee)
 		assert_equal mock_project, assigns(:project)
@@ -346,7 +346,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		Project.expects(:find).with('42').returns(mock_project)
 		mock_project.expects(:destroy).returns(true)
 
-		delete :destroy, :id => '42'
+		delete :destroy, request_params(:id => '42')
 		assert_equal mock_project, assigns(:project)
 	end
 

--- a/test/nested_belongs_to_test.rb
+++ b/test/nested_belongs_to_test.rb
@@ -29,7 +29,7 @@ class NestedBelongsToTest < ActionController::TestCase
 
   def test_assigns_country_and_state_and_city_on_create
     City.expects(:find).with(:all).returns([mock_city])
-    get :index, :state_id => '37', :country_id => '13'
+    get :index, request_params(:state_id => '37', :country_id => '13')
 
     assert_equal mock_country, assigns(:country)
     assert_equal mock_state, assigns(:state)
@@ -38,7 +38,7 @@ class NestedBelongsToTest < ActionController::TestCase
 
   def test_assigns_country_and_state_and_city_on_show
     City.expects(:find).with('42').returns(mock_city)
-    get :show, :id => '42', :state_id => '37', :country_id => '13'
+    get :show, request_params(:id => '42', :state_id => '37', :country_id => '13')
 
     assert_equal mock_country, assigns(:country)
     assert_equal mock_state, assigns(:state)
@@ -47,7 +47,7 @@ class NestedBelongsToTest < ActionController::TestCase
 
   def test_assigns_country_and_state_and_city_on_new
     City.expects(:build).returns(mock_city)
-    get :new, :state_id => '37', :country_id => '13'
+    get :new, request_params(:state_id => '37', :country_id => '13')
 
     assert_equal mock_country, assigns(:country)
     assert_equal mock_state, assigns(:state)
@@ -56,7 +56,7 @@ class NestedBelongsToTest < ActionController::TestCase
 
   def test_assigns_country_and_state_and_city_on_edit
     City.expects(:find).with('42').returns(mock_city)
-    get :edit, :id => '42', :state_id => '37', :country_id => '13'
+    get :edit, request_params(:id => '42', :state_id => '37', :country_id => '13')
 
     assert_equal mock_country, assigns(:country)
     assert_equal mock_state, assigns(:state)
@@ -66,7 +66,7 @@ class NestedBelongsToTest < ActionController::TestCase
   def test_assigns_country_and_state_and_city_on_create
     City.expects(:build).with({'these' => 'params'}).returns(mock_city)
     mock_city.expects(:save).returns(true)
-    post :create, :state_id => '37', :country_id => '13', :city => {:these => 'params'}
+    post :create, request_params(:state_id => '37', :country_id => '13', :city => {:these => 'params'})
 
     assert_equal mock_country, assigns(:country)
     assert_equal mock_state, assigns(:state)
@@ -76,7 +76,7 @@ class NestedBelongsToTest < ActionController::TestCase
   def test_assigns_country_and_state_and_city_on_update
     City.expects(:find).with('42').returns(mock_city)
     mock_city.expects(:update_attributes).returns(true)
-    put :update, :id => '42', :state_id => '37', :country_id => '13', :city => {:these => 'params'}
+    put :update, request_params(:id => '42', :state_id => '37', :country_id => '13', :city => {:these => 'params'})
 
     assert_equal mock_country, assigns(:country)
     assert_equal mock_state, assigns(:state)
@@ -86,7 +86,7 @@ class NestedBelongsToTest < ActionController::TestCase
   def test_assigns_country_and_state_and_city_on_destroy
     City.expects(:find).with('42').returns(mock_city)
     mock_city.expects(:destroy)
-    delete :destroy, :id => '42', :state_id => '37', :country_id => '13'
+    delete :destroy, request_params(:id => '42', :state_id => '37', :country_id => '13')
 
     assert_equal mock_country, assigns(:country)
     assert_equal mock_state, assigns(:state)

--- a/test/nested_belongs_to_with_shallow_test.rb
+++ b/test/nested_belongs_to_with_shallow_test.rb
@@ -31,7 +31,7 @@ class NestedBelongsToWithShallowTest < ActionController::TestCase
   def test_assigns_dresser_and_shelf_and_plate_on_index
     Shelf.expects(:find).with('37').twice.returns(mock_shelf)
     Plate.expects(:scoped).returns([mock_plate])
-    get :index, :shelf_id => '37'
+    get :index, request_params(:shelf_id => '37')
 
     assert_equal mock_dresser, assigns(:dresser)
     assert_equal mock_shelf, assigns(:shelf)
@@ -40,7 +40,7 @@ class NestedBelongsToWithShallowTest < ActionController::TestCase
 
   def test_assigns_dresser_and_shelf_and_plate_on_show
     should_find_parents
-    get :show, :id => '42'
+    get :show, request_params(:id => '42')
 
     assert_equal mock_dresser, assigns(:dresser)
     assert_equal mock_shelf, assigns(:shelf)
@@ -50,7 +50,7 @@ class NestedBelongsToWithShallowTest < ActionController::TestCase
   def test_assigns_dresser_and_shelf_and_plate_on_new
     Plate.expects(:build).returns(mock_plate)
     Shelf.expects(:find).with('37').twice.returns(mock_shelf)
-    get :new, :shelf_id => '37'
+    get :new, request_params(:shelf_id => '37')
 
     assert_equal mock_dresser, assigns(:dresser)
     assert_equal mock_shelf, assigns(:shelf)
@@ -59,7 +59,7 @@ class NestedBelongsToWithShallowTest < ActionController::TestCase
 
   def test_assigns_dresser_and_shelf_and_plate_on_edit
     should_find_parents
-    get :edit, :id => '42'
+    get :edit, request_params(:id => '42')
 
     assert_equal mock_dresser, assigns(:dresser)
     assert_equal mock_shelf, assigns(:shelf)
@@ -72,7 +72,7 @@ class NestedBelongsToWithShallowTest < ActionController::TestCase
 
     Plate.expects(:build).with({'these' => 'params'}).returns(mock_plate)
     mock_plate.expects(:save).returns(true)
-    post :create, :shelf_id => '37', :plate => {:these => 'params'}
+    post :create, request_params(:shelf_id => '37', :plate => {:these => 'params'})
 
     assert_equal mock_dresser, assigns(:dresser)
     assert_equal mock_shelf, assigns(:shelf)
@@ -82,7 +82,7 @@ class NestedBelongsToWithShallowTest < ActionController::TestCase
   def test_assigns_dresser_and_shelf_and_plate_on_update
     should_find_parents
     mock_plate.expects(:update_attributes).returns(true)
-    put :update, :id => '42', :plate => {:these => 'params'}
+    put :update, request_params(:id => '42', :plate => {:these => 'params'})
 
     assert_equal mock_dresser, assigns(:dresser)
     assert_equal mock_shelf, assigns(:shelf)
@@ -92,7 +92,7 @@ class NestedBelongsToWithShallowTest < ActionController::TestCase
   def test_assigns_dresser_and_shelf_and_plate_on_destroy
     should_find_parents
     mock_plate.expects(:destroy)
-    delete :destroy, :id => '42'
+    delete :destroy, request_params(:id => '42')
 
     assert_equal mock_dresser, assigns(:dresser)
     assert_equal mock_shelf, assigns(:shelf)

--- a/test/nested_model_with_shallow_test.rb
+++ b/test/nested_model_with_shallow_test.rb
@@ -50,7 +50,7 @@ class NestedModelWithShallowTest < ActionController::TestCase
 
   def test_assigns_subfaculty_and_speciality_and_group_on_edit
     should_find_parents
-    get :edit, :id => 'forty_two'
+    get :edit, request_params(:id => 'forty_two')
 
     assert_equal mock_subfaculty, assigns(:subfaculty)
     assert_equal mock_speciality, assigns(:speciality)
@@ -60,14 +60,14 @@ class NestedModelWithShallowTest < ActionController::TestCase
   def test_expose_a_newly_create_group_with_speciality
     Speciality.expects(:find).with('37').twice.returns(mock_speciality)
     Plan::Group.expects(:build).with({'these' => 'params'}).returns(mock_group(:save => true))
-    post :create, :speciality_id => '37', :group => {'these' => 'params'}
+    post :create, request_params(:speciality_id => '37', :group => {'these' => 'params'})
     assert_equal mock_group, assigns(:group)
   end
 
   def test_expose_a_update_group_with_speciality
     should_find_parents
     mock_group.expects(:update_attributes).with('these' => 'params').returns(true)
-    post :update, :id => 'forty_two', :group => {'these' => 'params'}
+    post :update, request_params(:id => 'forty_two', :group => {'these' => 'params'})
     assert_equal mock_group, assigns(:group)
   end
 
@@ -109,7 +109,7 @@ class TwoNestedModelWithShallowTest < ActionController::TestCase
 
   def test_assigns_subfaculty_and_speciality_and_group_on_new
     should_find_parents
-    get :new, :group_id => 'forty_two'
+    get :new, request_params(:group_id => 'forty_two')
 
     assert_equal mock_subfaculty, assigns(:subfaculty)
     assert_equal mock_speciality, assigns(:speciality)

--- a/test/nested_singleton_test.rb
+++ b/test/nested_singleton_test.rb
@@ -58,7 +58,7 @@ class NestedSingletonTest < ActionController::TestCase
     @controller = VenueController.new
     Party.expects(:find).with('37').returns(mock_party)
     mock_party.expects(:venue).returns(mock_venue)
-    get :show, :party_id => '37'
+    get :show, request_params(:party_id => '37')
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
   ensure
@@ -73,7 +73,7 @@ class NestedSingletonTest < ActionController::TestCase
     mock_party.expects(:venue).returns(mock_venue)
     mock_venue.expects(:address).returns(mock_address)
     mock_address.expects(:geolocation).returns(mock_geolocation)
-    get :show, :party_id => '37'
+    get :show, request_params(:party_id => '37')
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)
@@ -87,7 +87,7 @@ class NestedSingletonTest < ActionController::TestCase
     Party.expects(:find).with('37').returns(mock_party)
     mock_party.expects(:venue).returns(mock_venue)
     mock_venue.expects(:build_address).returns(mock_address)
-    get :new, :party_id => '37'
+    get :new, request_params(:party_id => '37')
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)
@@ -97,7 +97,7 @@ class NestedSingletonTest < ActionController::TestCase
     Party.expects(:find).with('37').returns(mock_party)
     mock_party.expects(:venue).returns(mock_venue)
     mock_venue.expects(:address).returns(mock_address)
-    get :edit, :party_id => '37'
+    get :edit, request_params(:party_id => '37')
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)
@@ -108,7 +108,7 @@ class NestedSingletonTest < ActionController::TestCase
     Party.expects(:find).with('37').returns(mock_party)
     mock_party.expects(:venue).returns(mock_venue)
     mock_venue.expects(:address).returns(mock_address)
-    get :show, :party_id => '37'
+    get :show, request_params(:party_id => '37')
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)
@@ -119,7 +119,7 @@ class NestedSingletonTest < ActionController::TestCase
     Party.expects(:find).with('37').returns(mock_party)
     mock_party.expects(:venue).returns(mock_venue)
     mock_venue.expects(:build_address).with({'these' => 'params'}).returns(mock_address(:save => true))
-    post :create, :party_id => '37', :address => {:these => 'params'}
+    post :create, request_params(:party_id => '37', :address => {:these => 'params'})
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)
@@ -129,7 +129,7 @@ class NestedSingletonTest < ActionController::TestCase
     Party.expects(:find).with('37').returns(mock_party)
     mock_party.expects(:venue).returns(mock_venue(:address => mock_address))
     mock_address.expects(:update_attributes).with({'these' => 'params'}).returns(mock_address(:save => true))
-    post :update, :party_id => '37', :address => {:these => 'params'}
+    post :update, request_params(:party_id => '37', :address => {:these => 'params'})
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)
@@ -141,7 +141,7 @@ class NestedSingletonTest < ActionController::TestCase
     mock_venue.expects(:address).returns(mock_address)
     @controller.expects(:parent_url).returns('http://test.host/')
     mock_address.expects(:destroy)
-    delete :destroy, :party_id => '37'
+    delete :destroy, request_params(:party_id => '37')
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)

--- a/test/optional_belongs_to_test.rb
+++ b/test/optional_belongs_to_test.rb
@@ -23,7 +23,7 @@ class OptionalTest < ActionController::TestCase
     Category.expects(:find).with('37').returns(mock_category)
     mock_category.expects(:products).returns(Product)
     Product.expects(:scoped).returns([mock_product])
-    get :index, :category_id => '37'
+    get :index, request_params(:category_id => '37')
     assert_equal mock_category, assigns(:category)
     assert_equal [mock_product], assigns(:products)
   end
@@ -39,14 +39,14 @@ class OptionalTest < ActionController::TestCase
     Category.expects(:find).with('37').returns(mock_category)
     mock_category.expects(:products).returns(Product)
     Product.expects(:find).with('42').returns(mock_product)
-    get :show, :id => '42', :category_id => '37'
+    get :show, request_params(:id => '42', :category_id => '37')
     assert_equal mock_category, assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
 
   def test_expose_the_requested_product_without_category
     Product.expects(:find).with('42').returns(mock_product)
-    get :show, :id => '42'
+    get :show, request_params(:id => '42')
     assert_nil assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -55,7 +55,7 @@ class OptionalTest < ActionController::TestCase
     Category.expects(:find).with('37').returns(mock_category)
     mock_category.expects(:products).returns(Product)
     Product.expects(:build).returns(mock_product)
-    get :new, :category_id => '37'
+    get :new, request_params(:category_id => '37')
     assert_equal mock_category, assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -71,14 +71,14 @@ class OptionalTest < ActionController::TestCase
     Category.expects(:find).with('37').returns(mock_category)
     mock_category.expects(:products).returns(Product)
     Product.expects(:find).with('42').returns(mock_product)
-    get :edit, :id => '42', :category_id => '37'
+    get :edit, request_params(:id => '42', :category_id => '37')
     assert_equal mock_category, assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
 
   def test_expose_the_requested_product_for_edition_without_category
     Product.expects(:find).with('42').returns(mock_product)
-    get :edit, :id => '42'
+    get :edit, request_params(:id => '42')
     assert_nil assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -87,14 +87,14 @@ class OptionalTest < ActionController::TestCase
     Category.expects(:find).with('37').returns(mock_category)
     mock_category.expects(:products).returns(Product)
     Product.expects(:build).with({'these' => 'params'}).returns(mock_product(:save => true))
-    post :create, :category_id => '37', :product => {:these => 'params'}
+    post :create, request_params(:category_id => '37', :product => {:these => 'params'})
     assert_equal mock_category, assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
 
   def test_expose_a_newly_create_product_without_category
     Product.expects(:new).with({'these' => 'params'}).returns(mock_product(:save => true))
-    post :create, :product => {:these => 'params'}
+    post :create, request_params(:product => {:these => 'params'})
     assert_nil assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -105,7 +105,7 @@ class OptionalTest < ActionController::TestCase
     Product.expects(:find).with('42').returns(mock_product)
     mock_product.expects(:update_attributes).with({'these' => 'params'}).returns(true)
 
-    put :update, :id => '42', :category_id => '37', :product => {:these => 'params'}
+    put :update, request_params(:id => '42', :category_id => '37', :product => {:these => 'params'})
     assert_equal mock_category, assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -114,7 +114,7 @@ class OptionalTest < ActionController::TestCase
     Product.expects(:find).with('42').returns(mock_product)
     mock_product.expects(:update_attributes).with({'these' => 'params'}).returns(true)
 
-    put :update, :id => '42', :product => {:these => 'params'}
+    put :update, request_params(:id => '42', :product => {:these => 'params'})
     assert_nil assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -126,7 +126,7 @@ class OptionalTest < ActionController::TestCase
     mock_product.expects(:destroy).returns(true)
     @controller.expects(:collection_url).returns('/')
 
-    delete :destroy, :id => '42', :category_id => '37'
+    delete :destroy, request_params(:id => '42', :category_id => '37')
     assert_equal mock_category, assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -136,7 +136,7 @@ class OptionalTest < ActionController::TestCase
     mock_product.expects(:destroy).returns(true)
     @controller.expects(:collection_url).returns('/')
 
-    delete :destroy, :id => '42'
+    delete :destroy, request_params(:id => '42')
     assert_nil assigns(:category)
     assert_equal mock_product, assigns(:product)
   end

--- a/test/polymorphic_test.rb
+++ b/test/polymorphic_test.rb
@@ -35,28 +35,28 @@ class PolymorphicFactoriesTest < ActionController::TestCase
 
   def test_expose_all_employees_as_instance_variable_on_index
     Employee.expects(:scoped).returns([mock_employee])
-    get :index, :factory_id => '37'
+    get :index, request_params(:factory_id => '37')
     assert_equal mock_factory, assigns(:factory)
     assert_equal [mock_employee], assigns(:employees)
   end
 
   def test_expose_the_requested_employee_on_show
     Employee.expects(:find).with('42').returns(mock_employee)
-    get :show, :id => '42', :factory_id => '37'
+    get :show, request_params(:id => '42', :factory_id => '37')
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
   end
 
   def test_expose_a_new_employee_on_new
     Employee.expects(:build).returns(mock_employee)
-    get :new, :factory_id => '37'
+    get :new, request_params(:factory_id => '37')
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
   end
 
   def test_expose_the_requested_employee_on_edit
     Employee.expects(:find).with('42').returns(mock_employee)
-    get :edit, :id => '42', :factory_id => '37'
+    get :edit, request_params(:id => '42', :factory_id => '37')
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
     assert_response :success
@@ -64,7 +64,7 @@ class PolymorphicFactoriesTest < ActionController::TestCase
 
   def test_expose_a_newly_create_employee_on_create
     Employee.expects(:build).with({'these' => 'params'}).returns(mock_employee(:save => true))
-    post :create, :factory_id => '37', :employee => {:these => 'params'}
+    post :create, request_params(:factory_id => '37', :employee => {:these => 'params'})
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -72,7 +72,7 @@ class PolymorphicFactoriesTest < ActionController::TestCase
   def test_update_the_requested_object_on_update
     Employee.expects(:find).with('42').returns(mock_employee)
     mock_employee.expects(:update_attributes).with({'these' => 'params'}).returns(true)
-    put :update, :id => '42', :factory_id => '37', :employee => {:these => 'params'}
+    put :update, request_params(:id => '42', :factory_id => '37', :employee => {:these => 'params'})
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -80,7 +80,7 @@ class PolymorphicFactoriesTest < ActionController::TestCase
   def test_the_requested_employee_is_destroyed_on_destroy
     Employee.expects(:find).with('42').returns(mock_employee)
     mock_employee.expects(:destroy)
-    delete :destroy, :id => '42', :factory_id => '37'
+    delete :destroy, request_params(:id => '42', :factory_id => '37')
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -89,7 +89,7 @@ class PolymorphicFactoriesTest < ActionController::TestCase
     mock_factory.stubs(:class).returns(Factory)
 
     Employee.expects(:scoped).returns([mock_employee])
-    get :index, :factory_id => '37'
+    get :index, request_params(:factory_id => '37')
 
     assert @controller.send(:parent?)
     assert_equal :factory, assigns(:parent_type)
@@ -122,28 +122,28 @@ class PolymorphicCompanyTest < ActionController::TestCase
 
   def test_expose_all_employees_as_instance_variable_on_index
     Employee.expects(:scoped).returns([mock_employee])
-    get :index, :company_id => '37'
+    get :index, request_params(:company_id => '37')
     assert_equal mock_company, assigns(:company)
     assert_equal [mock_employee], assigns(:employees)
   end
 
   def test_expose_the_requested_employee_on_show
     Employee.expects(:find).with('42').returns(mock_employee)
-    get :show, :id => '42', :company_id => '37'
+    get :show, request_params(:id => '42', :company_id => '37')
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)
   end
 
   def test_expose_a_new_employee_on_new
     Employee.expects(:build).returns(mock_employee)
-    get :new, :company_id => '37'
+    get :new, request_params(:company_id => '37')
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)
   end
 
   def test_expose_the_requested_employee_on_edit
     Employee.expects(:find).with('42').returns(mock_employee)
-    get :edit, :id => '42', :company_id => '37'
+    get :edit, request_params(:id => '42', :company_id => '37')
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)
     assert_response :success
@@ -151,7 +151,7 @@ class PolymorphicCompanyTest < ActionController::TestCase
 
   def test_expose_a_newly_create_employee_on_create
     Employee.expects(:build).with({'these' => 'params'}).returns(mock_employee(:save => true))
-    post :create, :company_id => '37', :employee => {:these => 'params'}
+    post :create, request_params(:company_id => '37', :employee => {:these => 'params'})
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -159,7 +159,7 @@ class PolymorphicCompanyTest < ActionController::TestCase
   def test_update_the_requested_object_on_update
     Employee.expects(:find).with('42').returns(mock_employee)
     mock_employee.expects(:update_attributes).with({'these' => 'params'}).returns(true)
-    put :update, :id => '42', :company_id => '37', :employee => {:these => 'params'}
+    put :update, request_params(:id => '42', :company_id => '37', :employee => {:these => 'params'})
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -167,7 +167,7 @@ class PolymorphicCompanyTest < ActionController::TestCase
   def test_the_requested_employee_is_destroyed_on_destroy
     Employee.expects(:find).with('42').returns(mock_employee)
     mock_employee.expects(:destroy)
-    delete :destroy, :id => '42', :company_id => '37'
+    delete :destroy, request_params(:id => '42', :company_id => '37')
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -176,7 +176,7 @@ class PolymorphicCompanyTest < ActionController::TestCase
     mock_company.stubs(:class).returns(Company)
 
     Employee.expects(:scoped).returns([mock_employee])
-    get :index, :company_id => '37'
+    get :index, request_params(:company_id => '37')
 
     assert @controller.send(:parent?)
     assert_equal :company, assigns(:parent_type)
@@ -204,7 +204,7 @@ class PolymorphicPhotosTest < ActionController::TestCase
   end
 
   def test_parent_as_instance_variable_on_index_when_method_overwritten
-    get :index, :user_id => '37'
+    get :index, request_params(:user_id => '37')
     assert_equal mock_user, assigns(:user)
   end
 

--- a/test/singleton_test.rb
+++ b/test/singleton_test.rb
@@ -28,7 +28,7 @@ class SingletonTest < ActionController::TestCase
   def test_expose_the_requested_manager_on_show
     Store.expects(:find).with('37').returns(mock_store)
     mock_store.expects(:manager).returns(mock_manager)
-    get :show, :store_id => '37'
+    get :show, request_params(:store_id => '37')
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)
   end
@@ -36,7 +36,7 @@ class SingletonTest < ActionController::TestCase
   def test_expose_a_new_manager_on_new
     Store.expects(:find).with('37').returns(mock_store)
     mock_store.expects(:build_manager).returns(mock_manager)
-    get :new, :store_id => '37'
+    get :new, request_params(:store_id => '37')
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)
   end
@@ -44,7 +44,7 @@ class SingletonTest < ActionController::TestCase
   def test_expose_the_requested_manager_on_edit
     Store.expects(:find).with('37').returns(mock_store)
     mock_store.expects(:manager).returns(mock_manager)
-    get :edit, :store_id => '37'
+    get :edit, request_params(:store_id => '37')
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)
     assert_response :success
@@ -53,7 +53,7 @@ class SingletonTest < ActionController::TestCase
   def test_expose_a_newly_create_manager_on_create
     Store.expects(:find).with('37').returns(mock_store)
     mock_store.expects(:build_manager).with({'these' => 'params'}).returns(mock_manager(:save => true))
-    post :create, :store_id => '37', :manager => {:these => 'params'}
+    post :create, request_params(:store_id => '37', :manager => {:these => 'params'})
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)
   end
@@ -61,7 +61,7 @@ class SingletonTest < ActionController::TestCase
   def test_update_the_requested_object_on_update
     Store.expects(:find).with('37').returns(mock_store(:manager => mock_manager))
     mock_manager.expects(:update_attributes).with({'these' => 'params'}).returns(true)
-    put :update, :store_id => '37', :manager => {:these => 'params'}
+    put :update, request_params(:store_id => '37', :manager => {:these => 'params'})
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)
   end
@@ -71,7 +71,7 @@ class SingletonTest < ActionController::TestCase
     mock_store.expects(:manager).returns(mock_manager)
     @controller.expects(:parent_url).returns('http://test.host/')
     mock_manager.expects(:destroy)
-    delete :destroy, :store_id => '37'
+    delete :destroy, request_params(:store_id => '37')
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)
   end

--- a/test/strong_parameters_test.rb
+++ b/test/strong_parameters_test.rb
@@ -25,12 +25,12 @@ class StrongParametersTest < ActionController::TestCase
 
   def test_permitted_params_from_new
     Widget.expects(:new).with(:permitted => 'param')
-    get :new, :widget => { :permitted => 'param', :prohibited => 'param' }
+    get :new, request_params(:widget => { :permitted => 'param', :prohibited => 'param' })
   end
 
   def test_permitted_params_from_create
     Widget.expects(:new).with(:permitted => 'param').returns(mock(:save => true))
-    post :create, :widget => { :permitted => 'param', :prohibited => 'param' }
+    post :create, request_params(:widget => { :permitted => 'param', :prohibited => 'param' })
   end
 
   def test_permitted_params_from_update
@@ -41,7 +41,7 @@ class StrongParametersTest < ActionController::TestCase
     mock_widget.stubs(:to_model).returns(mock_widget)
     mock_widget.stubs(:model_name).returns(Widget.model_name)
     Widget.expects(:find).with('42').returns(mock_widget)
-    put :update, :id => '42', :widget => {:permitted => 'param', :prohibited => 'param'}
+    put :update, request_params(:id => '42', :widget => {:permitted => 'param', :prohibited => 'param'})
   end
 
   # `permitted_params` has greater priority than `widget_params`
@@ -51,7 +51,7 @@ class StrongParametersTest < ActionController::TestCase
         private :widget_params
       end
       Widget.expects(:new).with(:permitted => 'param')
-      get :new, :widget => { :permitted => 'param', :prohibited => 'param' }
+      get :new, request_params(:widget => { :permitted => 'param', :prohibited => 'param' })
   end
 end
 
@@ -68,12 +68,12 @@ class StrongParametersWithoutPermittedParamsTest < ActionController::TestCase
 
   def test_permitted_params_from_new
     Widget.expects(:new).with(:permitted => 'param')
-    get :new, :widget => { :permitted => 'param', :prohibited => 'param' }
+    get :new, request_params(:widget => { :permitted => 'param', :prohibited => 'param' })
   end
 
   def test_permitted_params_from_create
     Widget.expects(:new).with(:permitted => 'param').returns(mock(:save => true))
-    post :create, :widget => { :permitted => 'param', :prohibited => 'param' }
+    post :create, request_params(:widget => { :permitted => 'param', :prohibited => 'param' })
   end
 
   def test_permitted_params_from_update
@@ -84,7 +84,7 @@ class StrongParametersWithoutPermittedParamsTest < ActionController::TestCase
     mock_widget.stubs(:to_model).returns(mock_widget)
     mock_widget.stubs(:model_name).returns(Widget.model_name)
     Widget.expects(:find).with('42').returns(mock_widget)
-    put :update, :id => '42', :widget => {:permitted => 'param', :prohibited => 'param'}
+    put :update, request_params(:id => '42', :widget => {:permitted => 'param', :prohibited => 'param'})
   end
 end
 
@@ -104,17 +104,17 @@ class StrongParametersIntegrationTest < ActionController::TestCase
 
   def test_permitted_empty_params_from_new
     Widget.expects(:new).with({})
-    get :new, {}
+    get :new, request_params({})
   end
 
   def test_permitted_params_from_new
     Widget.expects(:new).with('permitted' => 'param')
-    get :new, :widget => { :permitted => 'param', :prohibited => 'param' }
+    get :new, request_params(:widget => { :permitted => 'param', :prohibited => 'param' })
   end
 
   def test_permitted_params_from_create
     Widget.expects(:new).with('permitted' => 'param').returns(mock(:save => true))
-    post :create, :widget => { :permitted => 'param', :prohibited => 'param' }
+    post :create, request_params(:widget => { :permitted => 'param', :prohibited => 'param' })
   end
 
   def test_permitted_params_from_update
@@ -125,6 +125,6 @@ class StrongParametersIntegrationTest < ActionController::TestCase
     mock_widget.stubs(:to_model).returns(mock_widget)
     mock_widget.stubs(:model_name).returns(Widget.model_name)
     Widget.expects(:find).with('42').returns(mock_widget)
-    put :update, :id => '42', :widget => {:permitted => 'param', :prohibited => 'param'}
+    put :update, request_params(:id => '42', :widget => {:permitted => 'param', :prohibited => 'param'})
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,14 @@ require "action_controller"
 if ActionPack::VERSION::MAJOR >= 5
   require 'rails-controller-testing'
   Rails::Controller::Testing.install
+
+  def request_params(params)
+    { params: params }
+  end
+else
+  def request_params(params)
+    params
+  end
 end
 
 I18n.load_path << File.join(File.dirname(__FILE__), 'locales', 'en.yml')


### PR DESCRIPTION
Rails 5.1 release has been officially cut http://weblog.rubyonrails.org/2017/4/27/Rails-5-1-final/

Blocked by https://github.com/plataformatec/has_scope/pull/88