### PR TITLE
Test support for Ruby 2.4, drop unsupported configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,10 @@
 language: ruby
 rvm:
-  - 2.1.9
   - 2.2.5
   - 2.3.1
+  - 2.4.1
   - jruby-9.1.7.0
-  - rbx-2.2.10
 gemfile:
-  - test/gemfiles/Gemfile-Rails-3-2
-  - test/gemfiles/Gemfile-Rails-4-0
-  - test/gemfiles/Gemfile-Rails-4-1
   - test/gemfiles/Gemfile-Rails-4-2
   - test/gemfiles/Gemfile-Rails-5-0
   - test/gemfiles/Gemfile-Rails-5-1
-matrix:
-  exclude:
-    - rvm: 2.1.9
-      gemfile: test/gemfiles/Gemfile-Rails-5-0
-    - rvm: 2.1.9
-      gemfile: test/gemfiles/Gemfile-Rails-5-1
-  allow_failures:
-    - rvm: rbx-2.2.10

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+# Master (unreleased)
+
+* Supports Ruby 2.4
+* Remove support for Ruby < 2.2, Rails < 4.2
+* Fixed broken class name in belongs_to
+* Remove use of HttpCacheResponder
+* Correct request_name in isolated engines
+* Fix nested controllers and singleton option
+
 # Version 1.7.2
 
 * Support Rails 5.1

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
   s.files         = Dir["app/**/*", "lib/**/*", "README.md", "MIT-LICENSE"]
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = '>= 2.1'
+  s.required_ruby_version = '>= 2.2'
 
   s.add_dependency("responders")
-  s.add_dependency("actionpack", ">= 3.2", "< 5.2.x")
-  s.add_dependency("railties", ">= 3.2", "< 5.2.x")
+  s.add_dependency("actionpack", ">= 4.2", "< 5.2")
+  s.add_dependency("railties", ">= 4.2", "< 5.2")
   s.add_dependency("has_scope",  "~> 0.6")
 end


### PR DESCRIPTION
Add Ruby 2.4, released December 2016.
Drop Ruby 2.1, de-supported April 2017.
Community support for Rails 3.2/4.0 ended December 2015, 4.1 in 2016.