### PR TITLE
Please add support for API controllers.

### DIFF
--- a/lib/inherited_resources.rb
+++ b/lib/inherited_resources.rb
@@ -27,7 +27,7 @@ end
 
 ActiveSupport.on_load(:action_controller) do
   # We can remove this check and change to `on_load(:action_controller_base)` in Rails 5.2.
-  if self == ActionController::Base
+  if self == ActionController::Base || self == ActionController::API
     # If you cannot inherit from InheritedResources::Base you can call
     # inherit_resources in your controller to have all the required modules and
     # funcionality included.


### PR DESCRIPTION
Please add support to API controllers as well!

When I had to use API controllers with IR, I found that `inherit_resources` method was not available and found the source code was like this. Instead, I had to call the three lines in the method body. It would be great if the support was somehow built-in or at least documented. The API controllers worked exactly as I expected.