### PR TITLE
Fix URL helpers not working with ActionController::Parameters

### DIFF
--- a/lib/inherited_resources/url_helpers.rb
+++ b/lib/inherited_resources/url_helpers.rb
@@ -216,7 +216,7 @@ module InheritedResources
       prefix = prefix ? "#{prefix}_" : ''
       ivars << (ivars.empty? ? 'given_options' : ', given_options')
 
-      given_args_transform = defined?(ActionController::Parameters) ? 'given_args = given_args.collect { |arg| arg.respond_to?(:permitted?) ? arg.to_h : arg }' : ''
+      given_args_transform = 'given_args = given_args.collect { |arg| arg.respond_to?(:permitted?) ? arg.to_h : arg }'
 
       class_eval <<-URL_HELPERS, __FILE__, __LINE__
         protected

--- a/lib/inherited_resources/url_helpers.rb
+++ b/lib/inherited_resources/url_helpers.rb
@@ -216,7 +216,7 @@ module InheritedResources
       prefix = prefix ? "#{prefix}_" : ''
       ivars << (ivars.empty? ? 'given_options' : ', given_options')
 
-      given_args_transform = defined?(ActionController::Parameters) ? 'given_args = given_args.collect { |arg| arg.is_a?(ActionController::Parameters) ? arg.to_h : arg }' : ''
+      given_args_transform = defined?(ActionController::Parameters) ? 'given_args = given_args.collect { |arg| arg.respond_to?(:permitted?) ? arg.to_h : arg }' : ''
 
       class_eval <<-URL_HELPERS, __FILE__, __LINE__
         protected

--- a/lib/inherited_resources/url_helpers.rb
+++ b/lib/inherited_resources/url_helpers.rb
@@ -216,16 +216,20 @@ module InheritedResources
       prefix = prefix ? "#{prefix}_" : ''
       ivars << (ivars.empty? ? 'given_options' : ', given_options')
 
+      given_args_transform = defined?(ActionController::Parameters) ? 'given_args = given_args.collect { |arg| arg.is_a?(ActionController::Parameters) ? arg.to_h : arg }' : ''
+
       class_eval <<-URL_HELPERS, __FILE__, __LINE__
         protected
           undef :#{prefix}#{name}_path if method_defined? :#{prefix}#{name}_path
           def #{prefix}#{name}_path(*given_args)
+            #{given_args_transform}
             given_options = given_args.extract_options!
             #{prefix}#{segments}_path(#{ivars})
           end
 
           undef :#{prefix}#{name}_url if method_defined? :#{prefix}#{name}_url
           def #{prefix}#{name}_url(*given_args)
+            #{given_args_transform}
             given_options = given_args.extract_options!
             #{prefix}#{segments}_url(#{ivars})
           end

--- a/test/url_helpers_test.rb
+++ b/test/url_helpers_test.rb
@@ -992,4 +992,19 @@ class UrlHelpersTest < ActiveSupport::TestCase
       controller.send("edit_parent_#{path_or_url}")
     end
   end
+
+  if ActionPack::VERSION::MAJOR >= 4
+    def test_url_helpers_with_action_controller_parameters
+      parameters = ActionController::Parameters.new(:page => 2)
+      parameters.permit!
+
+      controller = HousesController.new
+      controller.instance_variable_set('@house', :house)
+
+      [:url, :path].each do |path_or_url|
+        controller.expects("houses_#{path_or_url}").with({'page' => 2}).once
+        controller.send("collection_#{path_or_url}", parameters)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Helpers like collection_url/path use extract_options! which won't work with ActionController::Parameters since it isn't a hash.

This PR adds a check and transform ActionController::Parameters to a hash if necessary, making URL helpers behave like the Rails ones when parameter is a ActionController::Parameters object.

Fix #439.