### PR TITLE
Fix dependencies so gem works with rails 5.2.1.rc1 and all other 5.2.x versions

### DIFF
--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2'
 
   s.add_dependency("responders")
-  s.add_dependency("actionpack", ">= 4.2", "<= 5.2")
-  s.add_dependency("railties", ">= 4.2", "<= 5.2")
+  s.add_dependency("actionpack", ">= 4.2", "< 5.3")
+  s.add_dependency("railties", ">= 4.2", "< 5.3")
   s.add_dependency("has_scope",  "~> 0.6")
 end


### PR DESCRIPTION
This resolves a bundle update problem for rails 5.2.1.rc1. The relevant output of `bundle update rails` is:

```
Bundler could not find compatible versions for gem "actionpack":
  In Gemfile:
    activeadmin (~> 1.3) was resolved to 1.3.0, which depends on
      inherited_resources (>= 1.7.0) was resolved to 1.8.0, which depends on
        actionpack (<= 5.2, >= 4.2)
```