### PR TITLE
Refactor url helpers

### DIFF
--- a/lib/inherited_resources/url_helpers.rb
+++ b/lib/inherited_resources/url_helpers.rb
@@ -223,7 +223,7 @@ module InheritedResources
 
       undef_method params_method_name if method_defined? params_method_name
 
-      define_method params_method_name do |given_options, *args|
+      define_method params_method_name do |given_args, given_options, *args|
         args << given_options
       end
       protected params_method_name
@@ -240,7 +240,7 @@ module InheritedResources
         def #{method_name}(*given_args)
           given_args = given_args.collect { |arg| arg.respond_to?(:permitted?) ? arg.to_h : arg }
           given_options = given_args.extract_options!
-          #{segments_method}(*#{params_method_name}(given_options, #{ivars.join(?,)}))
+          #{segments_method}(*#{params_method_name}(given_args, given_options, #{ivars.join(?,)}))
         end
       URL_HELPERS
       protected method_name

--- a/lib/inherited_resources/url_helpers.rb
+++ b/lib/inherited_resources/url_helpers.rb
@@ -213,7 +213,6 @@ module InheritedResources
       end
 
       ivars = ivars.present? ? Array(ivars) : []
-      ivars << 'given_options'
 
       define_params_helper(prefix, name, ivars)
       [:path, :url].each { |suffix| define_helper_method(prefix, name, suffix, segments, ivars) }
@@ -224,8 +223,8 @@ module InheritedResources
 
       undef_method params_method_name if method_defined? params_method_name
 
-      define_method params_method_name do |*args|
-        args
+      define_method params_method_name do |given_options, *args|
+        args << given_options
       end
       protected params_method_name
     end
@@ -241,7 +240,7 @@ module InheritedResources
         def #{method_name}(*given_args)
           given_args = given_args.collect { |arg| arg.respond_to?(:permitted?) ? arg.to_h : arg }
           given_options = given_args.extract_options!
-          #{segments_method}(*#{params_method_name}(#{ivars.join(?,)}))
+          #{segments_method}(*#{params_method_name}(given_options, #{ivars.join(?,)}))
         end
       URL_HELPERS
       protected method_name

--- a/lib/inherited_resources/url_helpers.rb
+++ b/lib/inherited_resources/url_helpers.rb
@@ -234,11 +234,10 @@ module InheritedResources
 
       undef_method method_name if method_defined? method_name
 
-      class_eval <<-URL_HELPERS, __FILE__, __LINE__
-        def #{method_name}(*given_args)
-          #{segments_method}(*#{params_method_name}(*given_args))
-        end
-      URL_HELPERS
+      define_method method_name do |*given_args|
+        given_args = send params_method_name, *given_args
+        send segments_method, *given_args
+      end
       protected method_name
     end
 

--- a/lib/inherited_resources/url_helpers.rb
+++ b/lib/inherited_resources/url_helpers.rb
@@ -213,21 +213,21 @@ module InheritedResources
         ivars    = ivars.join(', ')
       end
 
-      prefix = prefix ? "#{prefix}_" : ''
       ivars << (ivars.empty? ? 'given_options' : ', given_options')
 
-      ['_path', '_url'].each { |suffix| define_helper_method(prefix, name, suffix, segments, ivars) }
+      [:path, :url].each { |suffix| define_helper_method(prefix, name, suffix, segments, ivars) }
     end
 
     def define_helper_method(prefix, name, suffix, segments, ivars)
-      method_name = [prefix, name, suffix].join
+      method_name = [prefix, name, suffix].compact.join(?_)
+      segments_method = [prefix, segments, suffix].compact.join(?_)
 
       class_eval <<-URL_HELPERS, __FILE__, __LINE__
         undef :#{method_name} if method_defined? :#{method_name}
         def #{method_name}(*given_args)
           given_args = given_args.collect { |arg| arg.respond_to?(:permitted?) ? arg.to_h : arg }
           given_options = given_args.extract_options!
-          #{prefix}#{segments}#{suffix}(#{ivars})
+          #{segments_method}(#{ivars})
         end
         protected method_name
       URL_HELPERS

--- a/lib/inherited_resources/url_helpers.rb
+++ b/lib/inherited_resources/url_helpers.rb
@@ -222,15 +222,16 @@ module InheritedResources
       method_name = [prefix, name, suffix].compact.join(?_)
       segments_method = [prefix, segments, suffix].compact.join(?_)
 
+      undef_method method_name if method_defined? method_name
+
       class_eval <<-URL_HELPERS, __FILE__, __LINE__
-        undef :#{method_name} if method_defined? :#{method_name}
         def #{method_name}(*given_args)
           given_args = given_args.collect { |arg| arg.respond_to?(:permitted?) ? arg.to_h : arg }
           given_options = given_args.extract_options!
           #{segments_method}(#{ivars})
         end
-        protected method_name
       URL_HELPERS
+      protected method_name
     end
 
   end

--- a/lib/inherited_resources/url_helpers.rb
+++ b/lib/inherited_resources/url_helpers.rb
@@ -187,14 +187,13 @@ module InheritedResources
         resource_segments.join('_')
       end
 
-      ivars = ivars.present? ? Array(ivars) : []
-
       define_params_helper(prefix, name, singleton, polymorphic, parent_index, ivars)
-      [:path, :url].each { |suffix| define_helper_method(prefix, name, suffix, segments) }
+      define_helper_method(prefix, name, :path, segments)
+      define_helper_method(prefix, name, :url, segments)
     end
 
     def define_params_helper(prefix, name, singleton, polymorphic, parent_index, ivars)
-      params_method_name = ['', prefix, name, :params].compact.join(?_)
+      params_method_name = ['', prefix, name, :params].compact.join('_')
 
       undef_method params_method_name if method_defined? params_method_name
 
@@ -203,7 +202,7 @@ module InheritedResources
         given_options = given_args.extract_options!
 
         args = ivars.map do |ivar|
-          ivar.is_a?(Symbol) && ivar.to_s.start_with?(?@) ? instance_variable_get(ivar) : ivar
+          ivar.is_a?(Symbol) && ivar.to_s.start_with?('@') ? instance_variable_get(ivar) : ivar
         end
         args[parent_index] = parent if parent_index 
 
@@ -228,9 +227,9 @@ module InheritedResources
     end
 
     def define_helper_method(prefix, name, suffix, segments)
-      method_name = [prefix, name, suffix].compact.join(?_)
-      params_method_name = ['', prefix, name, :params].compact.join(?_)
-      segments_method = [prefix, segments, suffix].compact.join(?_)
+      method_name = [prefix, name, suffix].compact.join('_')
+      params_method_name = ['', prefix, name, :params].compact.join('_')
+      segments_method = [prefix, segments, suffix].compact.join('_')
 
       undef_method method_name if method_defined? method_name
 

--- a/lib/inherited_resources/url_helpers.rb
+++ b/lib/inherited_resources/url_helpers.rb
@@ -210,10 +210,10 @@ module InheritedResources
         ivars   << '.compact' if self.resources_configuration[:polymorphic][:optional]
       else
         segments = resource_segments.empty? ? 'root' : resource_segments.join('_')
-        ivars    = ivars.join(', ')
       end
 
-      ivars << (ivars.empty? ? 'given_options' : ', given_options')
+      ivars = ivars.present? ? Array(ivars) : []
+      ivars << 'given_options'
 
       [:path, :url].each { |suffix| define_helper_method(prefix, name, suffix, segments, ivars) }
     end
@@ -228,7 +228,7 @@ module InheritedResources
         def #{method_name}(*given_args)
           given_args = given_args.collect { |arg| arg.respond_to?(:permitted?) ? arg.to_h : arg }
           given_options = given_args.extract_options!
-          #{segments_method}(#{ivars})
+          #{segments_method}(#{ivars.join(?,)})
         end
       URL_HELPERS
       protected method_name


### PR DESCRIPTION

The current implementation of UrlHelpers#create_resources_url_helpers! uses a class eval of something like:
```ruby
  edit_book_folder_path(@book,(given_args.first || @folder),given_options)
```
This refactoring replaces the class eval with a define_method as [suggested by Aaron](https://tenderlovemaking.com/2013/03/03/dynamic_method_definitions.html).  The proposed implementation looks something like:
```ruby
  edit_book_folder_path _edit_book_folder_params(given_args)
```
The presupposition is that using a defined method is easier to reason about and troubleshoot than eval-ing a constructed list of interpolated parameters.

This module could possibly be clarified further but the scope of this PR is only the refactoring required to replace use of class_eval.  A future refactoring could, for example, decompose the params helper further for different scenarios.