### PR TITLE
Build only PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+
 language: ruby
 rvm:
   - 2.3


### PR DESCRIPTION
As with the other repositories, I'd like to save CI time by not having two duplicate TravisCI checks on each PR.