### PR TITLE
Fix warnings from running the test suite

### DIFF
--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -152,7 +152,10 @@ module InheritedResources
         polymorphic = options.delete(:polymorphic)
         finder      = options.delete(:finder)
 
-        include BelongsToHelpers if self.parents_symbols.empty?
+        if self.parents_symbols.empty?
+          include BelongsToHelpers
+          helper_method :parent, :parent?
+        end
 
         acts_as_polymorphic! if polymorphic || optional
         acts_as_shallow!     if shallow
@@ -218,7 +221,6 @@ module InheritedResources
         else
           create_resources_url_helpers!
         end
-        helper_method :parent, :parent?
       end
       alias :nested_belongs_to :belongs_to
 

--- a/lib/inherited_resources/polymorphic_helpers.rb
+++ b/lib/inherited_resources/polymorphic_helpers.rb
@@ -102,11 +102,13 @@ module InheritedResources
       # as parent types.
       #
       def parent_type
-        unless @parent_type
+        unless instance_variable_defined?(:@parent_type)
           symbols_for_association_chain
         end
 
-        @parent_type
+        if instance_variable_defined?(:@parent_type)
+          @parent_type
+        end
       end
 
       def parent_class

--- a/lib/inherited_resources/polymorphic_helpers.rb
+++ b/lib/inherited_resources/polymorphic_helpers.rb
@@ -120,7 +120,7 @@ module InheritedResources
       #
       def parent
         if parent_type
-          p = instance_variable_get("@#{parent_type}")
+          p = instance_variable_defined?("@#{parent_type}") && instance_variable_get("@#{parent_type}")
           p || instance_variable_set("@#{parent_type}", association_chain[-1])
         end
       end

--- a/test/aliases_test.rb
+++ b/test/aliases_test.rb
@@ -41,6 +41,16 @@ end
 class AliasesTest < ActionController::TestCase
   tests StudentsController
 
+  def setup
+    draw_routes do
+      resources :students
+    end
+  end
+
+  def teardown
+    clear_routes
+  end
+
   def test_assignments_before_calling_alias
     Student.stubs(:new).returns(mock_student)
     get :new

--- a/test/association_chain_test.rb
+++ b/test/association_chain_test.rb
@@ -31,7 +31,15 @@ class BeginOfAssociationChainTest < ActionController::TestCase
   tests PetsController
 
   def setup
+    draw_routes do
+      resources :pets
+    end
+
     @controller.current_user = mock()
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_begin_of_association_chain_is_called_on_index
@@ -95,8 +103,16 @@ class AssociationChainTest < ActionController::TestCase
   tests PuppetsController
 
   def setup
+    draw_routes do
+      resources :puppets
+    end
+
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_parent_is_added_to_association_chain

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -26,11 +26,19 @@ end
 
 module UserTestHelper
   def setup
+    draw_routes do
+      resources :users
+    end
+
     @controller_class    = Class.new(UsersController)
     @controller          = @controller_class.new
     @controller.request  = @request = new_request
     @controller.response = @response = new_response
     @controller.stubs(:user_url).returns("/")
+  end
+
+  def teardown
+    clear_routes
   end
 
   protected

--- a/test/belongs_to_test.rb
+++ b/test/belongs_to_test.rb
@@ -56,7 +56,7 @@ class BelongsToTest < ActionController::TestCase
     assert_equal mock_comment, assigns(:comment)
   end
 
-  def test_redirect_to_the_post_on_update_if_show_and_index_undefined
+  def test_redirect_to_the_post_on_create_if_show_and_index_undefined
     @controller.class.send(:actions, :all, except: [:show, :index])
     @controller.expects(:parent_url).returns('http://test.host/')
     Comment.expects(:build).with({'these' => 'params'}).returns(mock_comment(save: true))

--- a/test/belongs_to_test.rb
+++ b/test/belongs_to_test.rb
@@ -15,6 +15,7 @@ end
 class BelongsToTest < ActionController::TestCase
   tests CommentsController
 
+  # TODO: look into the failures as this should run randomly
   def self.test_order
     # version 5 defaults to random, which fails...
     MiniTest::Unit::VERSION.to_i >= 5 ? :alpha : super

--- a/test/belongs_to_test.rb
+++ b/test/belongs_to_test.rb
@@ -21,11 +21,19 @@ class BelongsToTest < ActionController::TestCase
   end
 
   def setup
+    draw_routes do
+      resources :comments, :posts
+    end
+
     Post.expects(:find).with('37').returns(mock_post)
     mock_post.expects(:comments).returns(Comment)
 
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_expose_all_comments_as_instance_variable_on_index

--- a/test/belongs_to_with_shallow_test.rb
+++ b/test/belongs_to_with_shallow_test.rb
@@ -16,11 +16,19 @@ class BelongsToWithShallowTest < ActionController::TestCase
   tests TagsController
 
   def setup
+    draw_routes do
+      resources :tags
+    end
+
     Post.expects(:find_by_slug).with('thirty_seven').returns(mock_post)
     mock_post.expects(:tags).returns(Tag)
 
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_expose_all_tags_as_instance_variable_on_index

--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -119,11 +119,11 @@ class DefaultsClassMethodTest < ActiveSupport::TestCase
     assert_equal :string, BooksController.send(:resources_configuration)[:self][:instance_name]
     assert_equal :strings, BooksController.send(:resources_configuration)[:self][:collection_name]
 
-    BooksController.send(:defaults, class_name: 'Fixnum', instance_name: :fixnum, collection_name: :fixnums)
+    BooksController.send(:defaults, class_name: 'Integer', instance_name: :integer, collection_name: :integers)
 
-    assert_equal Fixnum, BooksController.send(:resource_class)
-    assert_equal :fixnum, BooksController.send(:resources_configuration)[:self][:instance_name]
-    assert_equal :fixnums, BooksController.send(:resources_configuration)[:self][:collection_name]
+    assert_equal Integer, BooksController.send(:resource_class)
+    assert_equal :integer, BooksController.send(:resources_configuration)[:self][:instance_name]
+    assert_equal :integers, BooksController.send(:resources_configuration)[:self][:collection_name]
   end
 
   def test_defaults_raises_invalid_key

--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -70,6 +70,16 @@ module EmptyNamespace; end
 class ActionsClassMethodTest < ActionController::TestCase
   tests BooksController
 
+  def setup
+    draw_routes do
+      resources :books
+    end
+  end
+
+  def teardown
+    clear_routes
+  end
+
   def test_cannot_render_actions
     assert_raise AbstractController::ActionNotFound do
       get :new

--- a/test/customized_base_test.rb
+++ b/test/customized_base_test.rb
@@ -36,10 +36,18 @@ end
 
 module CarTestHelper
   def setup
+    draw_routes do
+      resources :cars
+    end
+
     @controller          = CarsController.new
     @controller.request  = @request  = new_request
     @controller.response = @response = new_response
     @controller.stubs(:car_url).returns("/")
+  end
+
+  def teardown
+    clear_routes
   end
 
   protected

--- a/test/customized_belongs_to_test.rb
+++ b/test/customized_belongs_to_test.rb
@@ -16,9 +16,17 @@ class CustomizedBelongsToTest < ActionController::TestCase
   tests ProfessorsController
 
   def setup
+    draw_routes do
+      resources :professors
+    end
+
     GreatSchool.expects(:find_by_title!).with('nice').returns(mock_school(professors: Professor))
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_index

--- a/test/customized_redirect_to_test.rb
+++ b/test/customized_redirect_to_test.rb
@@ -11,6 +11,16 @@ end
 class RedirectToIndexWithoutShowTest < ActionController::TestCase
   tests PostsController
 
+  def setup
+    draw_routes do
+      resources :posts
+    end
+  end
+
+  def teardown
+    clear_routes
+  end
+
   def test_redirect_index_url_after_create
     Post.stubs(:new).returns(mock_machine(save: true))
     assert !PostsController.respond_to?(:show)

--- a/test/defaults_test.rb
+++ b/test/defaults_test.rb
@@ -181,7 +181,7 @@ class User
 end
 class Admin::UsersController < InheritedResources::Base
 end
-class TwoPartNameModelForNamespacedController < ActionController::TestCase
+class AnotherTwoPartNameModelForNamespacedController < ActionController::TestCase
   tests Admin::UsersController
 
   def setup

--- a/test/defaults_test.rb
+++ b/test/defaults_test.rb
@@ -18,8 +18,16 @@ class DefaultsTest < ActionController::TestCase
   tests PaintersController
 
   def setup
+    draw_routes do
+      resources :painters
+    end
+
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_expose_all_painters_as_instance_variable
@@ -86,8 +94,18 @@ class DefaultsNamespaceTest < ActionController::TestCase
   tests University::LecturersController
 
   def setup
+    draw_routes do
+      namespace :university do
+        resources :lecturers
+      end
+    end
+
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_expose_all_lecturers_as_instance_variable

--- a/test/multiple_nested_optional_belongs_to_test.rb
+++ b/test/multiple_nested_optional_belongs_to_test.rb
@@ -16,8 +16,16 @@ class MultipleNestedOptionalTest < ActionController::TestCase
   tests ProjectsController
 
   def setup
+    draw_routes do
+      resources :projects
+    end
+
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   # INDEX

--- a/test/nested_belongs_to_test.rb
+++ b/test/nested_belongs_to_test.rb
@@ -18,6 +18,10 @@ class NestedBelongsToTest < ActionController::TestCase
   tests CitiesController
 
   def setup
+    draw_routes do
+      resources :cities
+    end
+
     Country.expects(:find).with('13').returns(mock_country)
     mock_country.expects(:states).returns(State)
     State.expects(:find).with('37').returns(mock_state)
@@ -25,6 +29,10 @@ class NestedBelongsToTest < ActionController::TestCase
 
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_assigns_country_and_state_and_city_on_index

--- a/test/nested_belongs_to_test.rb
+++ b/test/nested_belongs_to_test.rb
@@ -27,8 +27,8 @@ class NestedBelongsToTest < ActionController::TestCase
     @controller.stubs(:collection_url).returns('/')
   end
 
-  def test_assigns_country_and_state_and_city_on_create
-    City.expects(:find).with(:all).returns([mock_city])
+  def test_assigns_country_and_state_and_city_on_index
+    City.expects(:scoped).returns([mock_city])
     get :index, params: { state_id: '37', country_id: '13' }
 
     assert_equal mock_country, assigns(:country)

--- a/test/nested_belongs_to_with_shallow_test.rb
+++ b/test/nested_belongs_to_with_shallow_test.rb
@@ -17,6 +17,10 @@ class NestedBelongsToWithShallowTest < ActionController::TestCase
   tests PlatesController
 
   def setup
+    draw_routes do
+      resources :plates
+    end
+
     mock_shelf.expects(:dresser).returns(mock_dresser)
     mock_dresser.expects(:to_param).returns('13')
 
@@ -26,6 +30,10 @@ class NestedBelongsToWithShallowTest < ActionController::TestCase
 
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_assigns_dresser_and_shelf_and_plate_on_index

--- a/test/nested_model_with_shallow_test.rb
+++ b/test/nested_model_with_shallow_test.rb
@@ -37,6 +37,10 @@ class NestedModelWithShallowTest < ActionController::TestCase
   tests GroupsController
 
   def setup
+    draw_routes do
+      resources :groups
+    end
+
     mock_speciality.expects(:subfaculty).returns(mock_subfaculty)
     mock_subfaculty.expects(:to_param).returns('13')
 
@@ -46,6 +50,10 @@ class NestedModelWithShallowTest < ActionController::TestCase
 
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_assigns_subfaculty_and_speciality_and_group_on_edit
@@ -98,6 +106,10 @@ class TwoNestedModelWithShallowTest < ActionController::TestCase
   tests EducationsController
 
   def setup
+    draw_routes do
+      resources :educations
+    end
+
     mock_speciality.expects(:subfaculty).returns(mock_subfaculty)
     mock_subfaculty.expects(:to_param).returns('13')
     Subfaculty.expects(:find).with('13').returns(mock_subfaculty)
@@ -106,6 +118,10 @@ class TwoNestedModelWithShallowTest < ActionController::TestCase
 
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_assigns_subfaculty_and_speciality_and_group_on_new

--- a/test/nested_singleton_test.rb
+++ b/test/nested_singleton_test.rb
@@ -48,8 +48,22 @@ class NestedSingletonTest < ActionController::TestCase
   tests AddressController
 
   def setup
+    draw_routes do
+      resources :party do
+        resource :venue, controller: :venue do
+          resource :address, controller: :address do
+            resource :geolocation, controller: :geolocation
+          end
+        end
+      end
+    end
+
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_does_not_break_parent_controller

--- a/test/optional_belongs_to_test.rb
+++ b/test/optional_belongs_to_test.rb
@@ -15,8 +15,16 @@ class OptionalTest < ActionController::TestCase
   tests ProductsController
 
   def setup
+    draw_routes do
+      resources :products
+    end
+
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_expose_all_products_as_instance_variable_with_category

--- a/test/polymorphic_test.rb
+++ b/test/polymorphic_test.rb
@@ -26,11 +26,19 @@ class PolymorphicFactoriesTest < ActionController::TestCase
   tests EmployeesController
 
   def setup
+    draw_routes do
+      resources :employees
+    end
+
     Factory.expects(:find).with('37').returns(mock_factory)
     mock_factory.expects(:employees).returns(Employee)
 
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_expose_all_employees_as_instance_variable_on_index
@@ -114,11 +122,19 @@ class PolymorphicCompanyTest < ActionController::TestCase
   tests EmployeesController
 
   def setup
+    draw_routes do
+      resources :employees
+    end
+
     Company.expects(:find).with('37').returns(mock_company)
     mock_company.expects(:employees).returns(Employee)
 
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_expose_all_employees_as_instance_variable_on_index
@@ -202,7 +218,15 @@ class PolymorphicPhotosTest < ActionController::TestCase
   tests PhotosController
 
   def setup
+    draw_routes do
+      resources :photos
+    end
+
     User.expects(:find).with('37').returns(mock_user)
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_parent_as_instance_variable_on_index_when_method_overwritten

--- a/test/redirect_to_test.rb
+++ b/test/redirect_to_test.rb
@@ -27,6 +27,16 @@ end
 class RedirectToWithBlockTest < ActionController::TestCase
   tests MachinesController
 
+  def setup
+    draw_routes do
+      resources :machines
+    end
+  end
+
+  def teardown
+    clear_routes
+  end
+
   def test_redirect_to_the_given_url_on_create
     Machine.stubs(:new).returns(mock_machine(save: true))
     post :create

--- a/test/singleton_test.rb
+++ b/test/singleton_test.rb
@@ -20,8 +20,18 @@ class SingletonTest < ActionController::TestCase
   tests ManagersController
 
   def setup
+    draw_routes do
+      resources :store do
+        resource :manager
+      end
+    end
+
     @controller.stubs(:resource_url).returns('/')
     @controller.stubs(:collection_url).returns('/')
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_expose_the_requested_manager_on_show

--- a/test/strong_parameters_test.rb
+++ b/test/strong_parameters_test.rb
@@ -11,12 +11,20 @@ end
 # test usage of `permitted_params`
 class StrongParametersTest < ActionController::TestCase
   def setup
+    draw_routes do
+      resources :widgets
+    end
+
     @controller = WidgetsController.new
     @controller.stubs(:widget_url).returns("/")
     @controller.stubs(:permitted_params).returns(widget: {permitted: 'param'})
     class << @controller
       private :permitted_params
     end
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_permitted_params_from_new
@@ -54,12 +62,20 @@ end
 # test usage of `widget_params`
 class StrongParametersWithoutPermittedParamsTest < ActionController::TestCase
   def setup
+    draw_routes do
+      resources :widgets
+    end
+
     @controller = WidgetsController.new
     @controller.stubs(:widget_url).returns("/")
     @controller.stubs(:widget_params).returns(permitted: 'param')
     class << @controller
       private :widget_params
     end
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_permitted_params_from_new
@@ -87,6 +103,10 @@ end
 # test usage of `widget_params` integrated with strong parameters (not using stubs)
 class StrongParametersIntegrationTest < ActionController::TestCase
   def setup
+    draw_routes do
+      resources :widgets
+    end
+
     @controller = WidgetsController.new
     @controller.stubs(:widget_url).returns("/")
 
@@ -96,6 +116,10 @@ class StrongParametersIntegrationTest < ActionController::TestCase
       end
       private :widget_params
     end
+  end
+
+  def teardown
+    clear_routes
   end
 
   def test_permitted_empty_params_from_new

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,6 +36,14 @@ InheritedResources::Routes.draw do
   root to: 'posts#index'
 end
 
+def draw_routes(&block)
+  InheritedResources::Routes.draw(&block)
+end
+
+def clear_routes
+  InheritedResources::Routes.draw { }
+end
+
 ActionController::Base.send :include, InheritedResources::Routes.url_helpers
 
 # Add app base to load path

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,12 +29,6 @@ require 'inherited_resources'
 ActionController::Base.view_paths = File.join(File.dirname(__FILE__), 'views')
 
 InheritedResources::Routes = ActionDispatch::Routing::RouteSet.new
-InheritedResources::Routes.draw do
-  get ':controller(/:action(/:id))'
-  get ':controller(/:action)'
-  resources 'posts'
-  root to: 'posts#index'
-end
 
 def draw_routes(&block)
   InheritedResources::Routes.draw(&block)


### PR DESCRIPTION
When running the test suite, many warnings are being displayed which we should fix. To see the warnings alongside test case names, run tests using the verbose flag:

```
TESTOPTS=--verbose bundle exec rake
```

I'm not sure how easy some warnings will be to address but this is a start to tackle each one. If you have ideas or know how to address any, please feel free to share. Thanks!

## Todo List

- Once explicit resources are known, we can resolve the Rails 6 deprecation warning as we can start localizing required resources into each test rather than have them be global.
