### PR TITLE
General update to gem template files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,12 @@
-# encoding: UTF-8
-
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rdoc/task'
 
 desc 'Run tests for InheritedResources.'
 Rake::TestTask.new(:test) do |t|
-  t.pattern = 'test/**/*_test.rb'
+  t.pattern = "test/**/*_test.rb"
+  t.libs << "test"
+  t.libs << "lib"
   t.verbose = true
 end
 
@@ -21,4 +21,4 @@ Rake::RDocTask.new(:rdoc) do |rdoc|
 end
 
 # Make test the default task.
-task :default => :test
+task default: :test

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -1,5 +1,5 @@
-# -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inherited_resources/version"
 
 Gem::Specification.new do |s|

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version     = InheritedResources::VERSION.dup
   s.platform    = Gem::Platform::RUBY
   s.summary     = "Inherited Resources speeds up development by making your controllers inherit all restful actions so you just have to focus on what is important."
-  s.homepage    = "http://github.com/activeadmin/inherited_resources"
+  s.homepage    = "https://github.com/activeadmin/inherited_resources"
   s.description = "Inherited Resources speeds up development by making your controllers inherit all restful actions so you just have to focus on what is important."
   s.authors     = ['José Valim', 'Rafael Mendonça França']
   s.license     = "MIT"

--- a/test/aliases_test.rb
+++ b/test/aliases_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 def plain_text
   ActionPack::VERSION::MAJOR >= 5 ? :plain : :text

--- a/test/association_chain_test.rb
+++ b/test/association_chain_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class Pet
   extend ActiveModel::Naming
@@ -10,7 +10,7 @@ end
 
 class PetsController < InheritedResources::Base
   attr_accessor :current_user
-  
+
   def edit
     @pet = 'new pet'
     edit!

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class User
   extend ActiveModel::Naming

--- a/test/belongs_to_test.rb
+++ b/test/belongs_to_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class Post
   extend ActiveModel::Naming

--- a/test/belongs_to_with_shallow_test.rb
+++ b/test/belongs_to_with_shallow_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class Post
   extend ActiveModel::Naming

--- a/test/changelog_test.rb
+++ b/test/changelog_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class ChangelogTest < ActiveSupport::TestCase
 

--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class Book; end
 class Folder; end

--- a/test/customized_base_test.rb
+++ b/test/customized_base_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class Car
   extend ActiveModel::Naming

--- a/test/customized_belongs_to_test.rb
+++ b/test/customized_belongs_to_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class GreatSchool
 end

--- a/test/customized_redirect_to_test.rb
+++ b/test/customized_redirect_to_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class Post;
   def self.human_name; 'Post'; end

--- a/test/defaults_test.rb
+++ b/test/defaults_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class Malarz
   def self.human_name; 'Painter'; end

--- a/test/multiple_nested_optional_belongs_to_test.rb
+++ b/test/multiple_nested_optional_belongs_to_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class Student; end
 class Manager; end
@@ -222,7 +222,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 		assert_equal mock_manager, assigns(:manager)
 		assert_equal mock_project, assigns(:project)
 	end
-	
+
 	def test_expose_a_newly_created_project_with_employee
 		Employee.expects(:find).with('37').returns(mock_employee)
 		mock_employee.expects(:projects).returns(Project)

--- a/test/nested_belongs_to_test.rb
+++ b/test/nested_belongs_to_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class Country
 end
@@ -82,7 +82,7 @@ class NestedBelongsToTest < ActionController::TestCase
     assert_equal mock_state, assigns(:state)
     assert_equal mock_city, assigns(:city)
   end
-  
+
   def test_assigns_country_and_state_and_city_on_destroy
     City.expects(:find).with('42').returns(mock_city)
     mock_city.expects(:destroy)

--- a/test/nested_belongs_to_with_shallow_test.rb
+++ b/test/nested_belongs_to_with_shallow_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class Dresser
 end

--- a/test/nested_model_with_shallow_test.rb
+++ b/test/nested_model_with_shallow_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class Subfaculty
 end

--- a/test/nested_singleton_test.rb
+++ b/test/nested_singleton_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 # This test file is instead to test the how controller flow and actions
 # using a belongs_to association. This is done using mocks a la rspec.
@@ -11,7 +11,7 @@ class Venue
   extend ActiveModel::Naming
 end
 
-class Address 
+class Address
   extend ActiveModel::Naming
 end
 
@@ -25,7 +25,7 @@ class VenueController < InheritedResources::Base
   belongs_to :party
 end
 
-# for the slightly pathological 
+# for the slightly pathological
 # /party/37/venue/address case
 class AddressController < InheritedResources::Base
   defaults :singleton => true
@@ -92,7 +92,7 @@ class NestedSingletonTest < ActionController::TestCase
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)
   end
-  
+
   def test_expose_the_address_on_edit
     Party.expects(:find).with('37').returns(mock_party)
     mock_party.expects(:venue).returns(mock_venue)

--- a/test/optional_belongs_to_test.rb
+++ b/test/optional_belongs_to_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class Brands; end
 class Category; end

--- a/test/polymorphic_test.rb
+++ b/test/polymorphic_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class Factory; end
 class Company; end

--- a/test/redirect_to_test.rb
+++ b/test/redirect_to_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class Machine;
   def self.human_name; 'Machine'; end

--- a/test/singleton_test.rb
+++ b/test/singleton_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 # This test file is instead to test the how controller flow and actions
 # using a belongs_to association. This is done using mocks a la rspec.

--- a/test/strong_parameters_test.rb
+++ b/test/strong_parameters_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 if ActionPack::VERSION::MAJOR == 3
   require 'strong_parameters'

--- a/test/url_helpers_test.rb
+++ b/test/url_helpers_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('test_helper', File.dirname(__FILE__))
+require 'test_helper'
 
 class ModelBase
   extend ActiveModel::Naming
@@ -46,7 +46,7 @@ end
 
 class OwnersController < InheritedResources::Base
   defaults :singleton => true
-  
+
   belongs_to :house
 end
 
@@ -276,7 +276,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
       controller.send("resource_#{path_or_url}", :arg, :page => 1)
     end
   end
-  
+
   def test_url_helpers_on_singleton_belongs_to
     controller = FlamesController.new
     controller.instance_variable_set('@house', :house)
@@ -460,7 +460,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
       controller.send("resource_#{path_or_url}", :arg, :page => 1)
     end
   end
-  
+
   def test_url_helpers_on_nested_polymorphic_belongs_to
     house = House.new
     table = Table.new
@@ -508,7 +508,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     new_spot = Spot.new
     Spot.stubs(:new).returns(new_spot)
     new_spot.stubs(:persisted?).returns(false)
-    
+
     controller = SpotsController.new
     controller.instance_variable_set('@parent_type', :fork)
     controller.instance_variable_set('@house', house)


### PR DESCRIPTION
Since this library has been around for so long, the files that are generated when creating a gem (gemspec, Rakefile, etc.) have since changed. I've updated these files to be inline with what the same files would be from a newly generated gem. This has some nice advantages where in tests we can just use `require 'test_helper'` instead, for example. 👍🏻