### PR TITLE
Bump locked bundler to 2.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 .install_bundler: &install_bundler
   run:
     name: Install a specific bundler version
-    command: gem install bundler -v 1.17.1
+    command: gem install bundler -v 2.0.1
 
 .copy_current_gemfile: &copy_current_gemfile
   run:
@@ -20,7 +20,7 @@ version: 2.1
 .install_dependencies: &install_dependencies
   run:
     name: Install dependencies
-    command: bundle install --without development --path /home/circleci/project/vendor/bundle --retry 3 --jobs 3
+    command: BUNDLER_VERSION=2.0.1 bundle install --without development --path /home/circleci/project/vendor/bundle --retry 3 --jobs 3
 
 .save_cache: &save_cache
   save_cache:
@@ -31,7 +31,7 @@ version: 2.1
 .run_tests: &run_tests
   run:
     name: Run tests
-    command: bundle exec rake test TESTOPTS="--verbose"
+    command: BUNDLER_VERSION=2.0.1 bundle exec rake test TESTOPTS="--verbose"
 
 .test_steps: &test_steps
   - checkout

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,4 +162,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.17.1
+   2.0.1

--- a/test/gemfiles/Gemfile-Rails-5-0.lock
+++ b/test/gemfiles/Gemfile-Rails-5-0.lock
@@ -154,4 +154,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.17.1
+   2.0.1

--- a/test/gemfiles/Gemfile-Rails-5-1.lock
+++ b/test/gemfiles/Gemfile-Rails-5-1.lock
@@ -154,4 +154,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.17.1
+   2.0.1


### PR DESCRIPTION
This includes a workaround for docker-library/ruby#246, which I'll remove once docker-library/official-images#5258 lands.