### PR TITLE
Reconcile jruby 9.2 + Rails 6.0 base docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
 
   jruby92rails60beta:
     docker:
-      - image: ccistaging/jruby:9.2.0.0
+      - image: circleci/jruby:9.2.6.0
 
     environment:
       BUNDLE_GEMFILE: test/gemfiles/Gemfile-Rails-6-0-beta


### PR DESCRIPTION
Follow up to #483 and #482. Use the same base image and tag as the other jruby images.