### PR TITLE
Improve gemspec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,11 @@ version: 2.1
     name: Make sure gemfiles are up to date
     command: bundle exec ruby -Itest -e 'require "gemfiles/lint.rb"; Minitest.run'
 
+.check_gemspec: &check_gemspec
+  run:
+    name: Make sure gemspec builds without warnings
+    command: bundle exec ruby -Itest -e 'require "gemfiles/gemspec_lint.rb"; Minitest.run'
+
 .run_tests: &run_tests
   run:
     name: Run tests
@@ -46,6 +51,7 @@ version: 2.1
   - *install_dependencies
   - *save_cache
   - *check_gemfiles
+  - *check_gemspec
   - *run_tests
 
 jobs:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (>= 5.0, < 6.0)
       has_scope (~> 0.6)
       railties (>= 5.0, < 6.0)
-      responders
+      responders (~> 2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -8,18 +8,20 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.summary     = "Inherited Resources speeds up development by making your controllers inherit all restful actions so you just have to focus on what is important."
   s.homepage    = "https://github.com/activeadmin/inherited_resources"
-  s.description = "Inherited Resources speeds up development by making your controllers inherit all restful actions so you just have to focus on what is important."
+  s.description = <<~MSG
+    Inherited Resources speeds up development by making your controllers inherit all restful actions so you just have to focus on what is important.
+    It makes your controllers more powerful and cleaner at the same time.
+  MSG
+
   s.authors     = ['José Valim', 'Rafael Mendonça França']
   s.license     = "MIT"
-
-  s.rubyforge_project = "inherited_resources"
 
   s.files         = Dir["app/**/*", "lib/**/*", "README.md", "MIT-LICENSE"]
   s.require_paths = ["lib"]
 
   s.required_ruby_version = '>= 2.3'
 
-  s.add_dependency("responders")
+  s.add_dependency("responders", "~> 2.0")
   s.add_dependency("actionpack", ">= 5.0", "< 6.0")
   s.add_dependency("railties", ">= 5.0", "< 6.0")
   s.add_dependency("has_scope",  "~> 0.6")

--- a/test/gemfiles/gemspec_lint.rb
+++ b/test/gemfiles/gemspec_lint.rb
@@ -1,0 +1,21 @@
+require "minitest"
+require "open3"
+require "inherited_resources/version"
+
+class GemspecTest < Minitest::Test
+  def setup
+    @build = Open3.capture3("gem build inherited_resources.gemspec")
+  end
+
+  def teardown
+    File.delete("inherited_resources-#{InheritedResources::VERSION}.gem")
+  end
+
+  def test_has_no_warnings
+    refute_includes @build[1], "WARNING"
+  end
+
+  def test_succeeds
+    assert_equal true, @build[2].success?
+  end
+end


### PR DESCRIPTION
This PR makes sure our gemspec builds without warnings. It fixes the following warnings:

```
WARNING:  description and summary are identical
WARNING:  open-ended dependency on responders (>= 0) is not recommended, use a bounded requirement, such as '~> x.y'
```

And also removes the `rubyforge_project` attribute since it currently does nothing and it will be deprecated soon.
