### PR TITLE
Use #update instead of newly deprecated #update_attributes

### DIFF
--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -68,14 +68,14 @@ module InheritedResources
 
       # Responsible for updating the resource in :update method. This allow you
       # to handle how the resource is going to be updated, let's say in a different
-      # way than the usual :update_attributes:
+      # way than the usual :update:
       #
       #   def update_resource(object, attributes)
       #     object.reset_password!(attributes)
       #   end
       #
       def update_resource(object, attributes)
-        object.update_attributes(*attributes)
+        object.update(*attributes)
       end
 
       # Handle the :destroy method for the resource. Overwrite it to call your

--- a/test/aliases_test.rb
+++ b/test/aliases_test.rb
@@ -114,14 +114,14 @@ class AliasesTest < ActionController::TestCase
   end
 
   def test_wont_render_edit_template_on_update_with_failure_if_failure_block_is_given
-    Student.stubs(:find).returns(mock_student(update_attributes: false, errors: { fail: true }))
+    Student.stubs(:find).returns(mock_student(update: false, errors: { fail: true }))
     put :update, params: { id: '42' }
     assert_response :success
     assert_equal "I won't render!", @response.body
   end
 
   def test_dumb_responder_quietly_receives_everything_on_success
-    Student.stubs(:find).returns(mock_student(update_attributes: true))
+    Student.stubs(:find).returns(mock_student(update: true))
     @controller.stubs(:resource_url).returns('http://test.host/')
     put :update, params: { id: '42', student: {these: 'params'} }
     assert_equal mock_student, assigns(:student)

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -242,7 +242,7 @@ class UpdateActionBaseTest < ActionController::TestCase
 
   def test_update_the_requested_object
     User.expects(:find).with('42').returns(mock_user)
-    mock_user.expects(:update_attributes).with({'these' => 'params'}).returns(true)
+    mock_user.expects(:update).with({'these' => 'params'}).returns(true)
     put :update, params: { id: '42', user: {these: 'params'} }
     assert_equal mock_user, assigns(:user)
   end
@@ -250,7 +250,7 @@ class UpdateActionBaseTest < ActionController::TestCase
   def test_update_the_requested_object_when_setted_role
     @controller.class.send(:with_role, :admin)
     User.expects(:find).with('42').returns(mock_user)
-    mock_user.expects(:update_attributes).with({'these' => 'params'}, {as: :admin}).returns(true)
+    mock_user.expects(:update).with({'these' => 'params'}, {as: :admin}).returns(true)
     put :update, params: { id: '42', user: {these: 'params'} }
     assert_equal mock_user, assigns(:user)
   end
@@ -258,13 +258,13 @@ class UpdateActionBaseTest < ActionController::TestCase
   def test_update_the_requested_object_when_setted_without_protection
     @controller.class.send(:without_protection, true)
     User.expects(:find).with('42').returns(mock_user)
-    mock_user.expects(:update_attributes).with({'these' => 'params'}, {without_protection: true}).returns(true)
+    mock_user.expects(:update).with({'these' => 'params'}, {without_protection: true}).returns(true)
     put :update, params: { id: '42', user: {these: 'params'} }
     assert_equal mock_user, assigns(:user)
   end
 
   def test_redirect_to_the_updated_user
-    User.stubs(:find).returns(mock_user(update_attributes: true))
+    User.stubs(:find).returns(mock_user(update: true))
     @controller.expects(:resource_url).returns('http://test.host/')
     put :update, params: { id: '42' }
     assert_redirected_to 'http://test.host/'
@@ -272,33 +272,33 @@ class UpdateActionBaseTest < ActionController::TestCase
 
   def test_redirect_to_the_users_list_if_show_undefined
     @controller.class.send(:actions, :all, except: :show)
-    User.stubs(:find).returns(mock_user(update_attributes: true))
+    User.stubs(:find).returns(mock_user(update: true))
     @controller.expects(:collection_url).returns('http://test.host/')
     put :update, params: { id: '42' }
     assert_redirected_to 'http://test.host/'
   end
 
   def test_show_flash_message_when_success
-    User.stubs(:find).returns(mock_user(update_attributes: true))
+    User.stubs(:find).returns(mock_user(update: true))
     put :update, params: { id: '42' }
     assert_equal flash[:notice], 'User was successfully updated.'
   end
 
   def test_show_flash_message_with_javascript_request_when_success
-    User.stubs(:find).returns(mock_user(update_attributes: true))
+    User.stubs(:find).returns(mock_user(update: true))
     post :update, params: { id: '42' }, format: :js
     assert_equal flash[:notice], 'User was successfully updated.'
   end
 
   def test_render_edit_template_when_user_cannot_be_saved
-    User.stubs(:find).returns(mock_user(update_attributes: false, errors: {some: :error}))
+    User.stubs(:find).returns(mock_user(update: false, errors: {some: :error}))
     put :update, params: { id: '42' }
     assert_response :success
     assert_equal "Edit HTML", @response.body.strip
   end
 
   def test_dont_show_flash_message_when_user_cannot_be_saved
-    User.stubs(:find).returns(mock_user(update_attributes: false, errors: {some: :error}))
+    User.stubs(:find).returns(mock_user(update: false, errors: {some: :error}))
     put :update, params: { id: '42' }
     assert flash.empty?
   end

--- a/test/belongs_to_test.rb
+++ b/test/belongs_to_test.rb
@@ -65,7 +65,7 @@ class BelongsToTest < ActionController::TestCase
 
   def test_update_the_requested_object_on_update
     Comment.expects(:find).with('42').returns(mock_comment)
-    mock_comment.expects(:update_attributes).with({'these' => 'params'}).returns(true)
+    mock_comment.expects(:update).with({'these' => 'params'}).returns(true)
     put :update, params: { id: '42', post_id: '37', comment: {these: 'params'} }
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
@@ -138,7 +138,7 @@ class BelongsToWithRedirectsTest < ActionController::TestCase
   end
 
   def test_redirect_to_the_post_on_update_if_show_and_index_undefined
-    Reply.stubs(:find).returns(mock_reply(update_attributes: true))
+    Reply.stubs(:find).returns(mock_reply(update: true))
     @controller.expects(:parent_url).returns('http://test.host/')
     put :update, params: { id: '42', post_id: '37', reply: { these: 'params' } }
     assert_redirected_to 'http://test.host/'

--- a/test/belongs_to_with_shallow_test.rb
+++ b/test/belongs_to_with_shallow_test.rb
@@ -67,7 +67,7 @@ class BelongsToWithShallowTest < ActionController::TestCase
 
   def test_update_the_requested_object_on_update
     should_find_parents
-    mock_tag.expects(:update_attributes).with({'these' => 'params'}).returns(true)
+    mock_tag.expects(:update).with({'these' => 'params'}).returns(true)
     put :update, params: { id: '42', tag: {these: 'params'} }
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)

--- a/test/customized_belongs_to_test.rb
+++ b/test/customized_belongs_to_test.rb
@@ -59,7 +59,7 @@ class CustomizedBelongsToTest < ActionController::TestCase
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_update
-    Professor.stubs(:find).returns(mock_professor(update_attributes: true))
+    Professor.stubs(:find).returns(mock_professor(update: true))
     put :update, params: { id: 42, school_title: 'nice' }
     assert_equal mock_school, assigns(:great_school)
   end

--- a/test/customized_redirect_to_test.rb
+++ b/test/customized_redirect_to_test.rb
@@ -29,7 +29,7 @@ class RedirectToIndexWithoutShowTest < ActionController::TestCase
   end
 
   def test_redirect_to_index_url_after_update
-    Post.stubs(:find).returns(mock_machine(update_attributes: true))
+    Post.stubs(:find).returns(mock_machine(update: true))
     assert !PostsController.respond_to?(:show)
     put :update, params: { id: '42' }
     assert_redirected_to 'http://test.host/posts'

--- a/test/defaults_test.rb
+++ b/test/defaults_test.rb
@@ -60,7 +60,7 @@ class DefaultsTest < ActionController::TestCase
 
   def test_update_the_requested_object
     Malarz.expects(:find_by_slug).with('forty_two').returns(mock_painter)
-    mock_painter.expects(:update_attributes).with({'these' => 'params'}).returns(true)
+    mock_painter.expects(:update).with({'these' => 'params'}).returns(true)
     put :update, params: { id: 'forty_two', malarz: {these: 'params'} }
     assert_equal mock_painter, assigns(:malarz)
   end
@@ -135,7 +135,7 @@ class DefaultsNamespaceTest < ActionController::TestCase
 
   def test_update_the_lecturer
     Lecturer.expects(:find_by_slug).with('forty_two').returns(mock_lecturer)
-    mock_lecturer.expects(:update_attributes).with({'these' => 'params'}).returns(true)
+    mock_lecturer.expects(:update).with({'these' => 'params'}).returns(true)
     put :update, params: { id: 'forty_two', lecturer: {these: 'params'} }
     assert_equal mock_lecturer, assigns(:lecturer)
   end

--- a/test/multiple_nested_optional_belongs_to_test.rb
+++ b/test/multiple_nested_optional_belongs_to_test.rb
@@ -263,7 +263,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     Student.expects(:find).with('37').returns(mock_student)
     mock_student.expects(:projects).returns(Project)
     Project.expects(:find).with('42').returns(mock_project)
-    mock_project.expects(:update_attributes).with({ 'these' => 'params' }).returns(true)
+    mock_project.expects(:update).with({ 'these' => 'params' }).returns(true)
     put :update, params: { id: '42', student_id: '37', project: { these: 'params' } }
     assert_equal mock_student, assigns(:student)
     assert_equal mock_project, assigns(:project)
@@ -273,7 +273,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     Manager.expects(:find).with('37').returns(mock_manager)
     mock_manager.expects(:projects).returns(Project)
     Project.expects(:find).with('42').returns(mock_project)
-    mock_project.expects(:update_attributes).with({ 'these' => 'params' }).returns(true)
+    mock_project.expects(:update).with({ 'these' => 'params' }).returns(true)
     put :update, params: { id: '42', manager_id: '37', project: { these: 'params' } }
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_project, assigns(:project)
@@ -283,7 +283,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     Employee.expects(:find).with('37').returns(mock_employee)
     mock_employee.expects(:projects).returns(Project)
     Project.expects(:find).with('42').returns(mock_project)
-    mock_project.expects(:update_attributes).with({ 'these' => 'params' }).returns(true)
+    mock_project.expects(:update).with({ 'these' => 'params' }).returns(true)
     put :update, params: { id: '42', employee_id: '37', project: { these: 'params' } }
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
@@ -295,7 +295,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     Employee.expects(:find).with('13').returns(mock_employee)
     mock_employee.expects(:projects).returns(Project)
     Project.expects(:find).with('42').returns(mock_project)
-    mock_project.expects(:update_attributes).with({ 'these' => 'params' }).returns(true)
+    mock_project.expects(:update).with({ 'these' => 'params' }).returns(true)
     put :update, params: { id: '42', manager_id: '37', employee_id: '13', project: { these: 'params' } }
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_employee, assigns(:employee)

--- a/test/nested_belongs_to_test.rb
+++ b/test/nested_belongs_to_test.rb
@@ -82,7 +82,7 @@ class NestedBelongsToTest < ActionController::TestCase
 
   def test_assigns_country_and_state_and_city_on_update
     City.expects(:find).with('42').returns(mock_city)
-    mock_city.expects(:update_attributes).returns(true)
+    mock_city.expects(:update).returns(true)
     put :update, params: { id: '42', state_id: '37', country_id: '13', city: {these: 'params'} }
 
     assert_equal mock_country, assigns(:country)

--- a/test/nested_belongs_to_with_shallow_test.rb
+++ b/test/nested_belongs_to_with_shallow_test.rb
@@ -87,7 +87,7 @@ class NestedBelongsToWithShallowTest < ActionController::TestCase
 
   def test_assigns_dresser_and_shelf_and_plate_on_update
     should_find_parents
-    mock_plate.expects(:update_attributes).returns(true)
+    mock_plate.expects(:update).returns(true)
     put :update, params: { id: '42', plate: {these: 'params'} }
 
     assert_equal mock_dresser, assigns(:dresser)

--- a/test/nested_model_with_shallow_test.rb
+++ b/test/nested_model_with_shallow_test.rb
@@ -71,7 +71,7 @@ class NestedModelWithShallowTest < ActionController::TestCase
 
   def test_expose_a_update_group_with_speciality
     should_find_parents
-    mock_group.expects(:update_attributes).with('these' => 'params').returns(true)
+    mock_group.expects(:update).with('these' => 'params').returns(true)
     post :update, params: { id: 'forty_two', group: {'these' => 'params'} }
     assert_equal mock_group, assigns(:group)
   end

--- a/test/nested_singleton_test.rb
+++ b/test/nested_singleton_test.rb
@@ -138,7 +138,7 @@ class NestedSingletonTest < ActionController::TestCase
   def test_update_the_requested_object_on_update
     Party.expects(:find).with('37').returns(mock_party)
     mock_party.expects(:venue).returns(mock_venue(address: mock_address))
-    mock_address.expects(:update_attributes).with({'these' => 'params'}).returns(mock_address(save: true))
+    mock_address.expects(:update).with({'these' => 'params'}).returns(mock_address(save: true))
     post :update, params: { party_id: '37', address: {these: 'params'} }
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)

--- a/test/optional_belongs_to_test.rb
+++ b/test/optional_belongs_to_test.rb
@@ -110,7 +110,7 @@ class OptionalTest < ActionController::TestCase
     Category.expects(:find).with('37').returns(mock_category)
     mock_category.expects(:products).returns(Product)
     Product.expects(:find).with('42').returns(mock_product)
-    mock_product.expects(:update_attributes).with({'these' => 'params'}).returns(true)
+    mock_product.expects(:update).with({'these' => 'params'}).returns(true)
 
     put :update, params: { id: '42', category_id: '37', product: {these: 'params'} }
     assert_equal mock_category, assigns(:category)
@@ -119,7 +119,7 @@ class OptionalTest < ActionController::TestCase
 
   def test_update_the_requested_object_without_category
     Product.expects(:find).with('42').returns(mock_product)
-    mock_product.expects(:update_attributes).with({'these' => 'params'}).returns(true)
+    mock_product.expects(:update).with({'these' => 'params'}).returns(true)
 
     put :update, params: { id: '42', product: {these: 'params'} }
     assert_nil assigns(:category)

--- a/test/polymorphic_test.rb
+++ b/test/polymorphic_test.rb
@@ -79,7 +79,7 @@ class PolymorphicFactoriesTest < ActionController::TestCase
 
   def test_update_the_requested_object_on_update
     Employee.expects(:find).with('42').returns(mock_employee)
-    mock_employee.expects(:update_attributes).with({'these' => 'params'}).returns(true)
+    mock_employee.expects(:update).with({'these' => 'params'}).returns(true)
     put :update, params: { id: '42', factory_id: '37', employee: {these: 'params'} }
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
@@ -175,7 +175,7 @@ class PolymorphicCompanyTest < ActionController::TestCase
 
   def test_update_the_requested_object_on_update
     Employee.expects(:find).with('42').returns(mock_employee)
-    mock_employee.expects(:update_attributes).with({'these' => 'params'}).returns(true)
+    mock_employee.expects(:update).with({'these' => 'params'}).returns(true)
     put :update, params: { id: '42', company_id: '37', employee: {these: 'params'} }
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)

--- a/test/redirect_to_test.rb
+++ b/test/redirect_to_test.rb
@@ -44,7 +44,7 @@ class RedirectToWithBlockTest < ActionController::TestCase
   end
 
   def test_redirect_to_the_given_url_on_update
-    Machine.stubs(:find).returns(mock_machine(update_attributes: true))
+    Machine.stubs(:find).returns(mock_machine(update: true))
     put :update, params: { id: '42' }
     assert_redirected_to 'http://test.host/update'
   end

--- a/test/singleton_test.rb
+++ b/test/singleton_test.rb
@@ -66,7 +66,7 @@ class SingletonTest < ActionController::TestCase
 
   def test_update_the_requested_object_on_update
     Store.expects(:find).with('37').returns(mock_store(manager: mock_manager))
-    mock_manager.expects(:update_attributes).with({'these' => 'params'}).returns(true)
+    mock_manager.expects(:update).with({'these' => 'params'}).returns(true)
     put :update, params: { store_id: '37', manager: {these: 'params'} }
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)

--- a/test/strong_parameters_test.rb
+++ b/test/strong_parameters_test.rb
@@ -40,7 +40,7 @@ class StrongParametersTest < ActionController::TestCase
   def test_permitted_params_from_update
     mock_widget = mock
     mock_widget.stubs(:class).returns(Widget)
-    mock_widget.expects(:update_attributes).with(permitted: 'param')
+    mock_widget.expects(:update).with(permitted: 'param')
     mock_widget.stubs(:persisted?).returns(true)
     mock_widget.stubs(:to_model).returns(mock_widget)
     mock_widget.stubs(:model_name).returns(Widget.model_name)
@@ -91,7 +91,7 @@ class StrongParametersWithoutPermittedParamsTest < ActionController::TestCase
   def test_permitted_params_from_update
     mock_widget = mock
     mock_widget.stubs(:class).returns(Widget)
-    mock_widget.expects(:update_attributes).with(permitted: 'param')
+    mock_widget.expects(:update).with(permitted: 'param')
     mock_widget.stubs(:persisted?).returns(true)
     mock_widget.stubs(:to_model).returns(mock_widget)
     mock_widget.stubs(:model_name).returns(Widget.model_name)
@@ -140,7 +140,7 @@ class StrongParametersIntegrationTest < ActionController::TestCase
   def test_permitted_params_from_update
     mock_widget = mock
     mock_widget.stubs(:class).returns(Widget)
-    mock_widget.expects(:update_attributes).with('permitted' => 'param')
+    mock_widget.expects(:update).with('permitted' => 'param')
     mock_widget.stubs(:persisted?).returns(true)
     mock_widget.stubs(:to_model).returns(mock_widget)
     mock_widget.stubs(:model_name).returns(Widget.model_name)


### PR DESCRIPTION
Fixes https://github.com/activeadmin/inherited_resources/issues/490.

This is just to deal with a deprecation warning that is coming in Rails 6