### PR TITLE
Wrap Gemfile gems with development group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ version: 2.1
 .install_dependencies: &install_dependencies
   run:
     name: Install dependencies
-    command: bundle install --without development --path /home/circleci/project/vendor/bundle --retry 3 --jobs 3
+    command: bundle install --path /home/circleci/project/vendor/bundle --retry 3 --jobs 3
 
 .save_cache: &save_cache
   save_cache:

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,12 @@ source 'https://rubygems.org'
 
 gemspec path: '.'
 
-gem 'rails', '~> 5.2.a'
+group :development do
+  gem 'rails', '~> 5.2.a'
 
-gem 'mocha'
-gem 'minitest-rg'
-gem 'rails-controller-testing'
-gem 'rubocop'
-gem 'chandler', '0.9.0'
+  gem 'mocha'
+  gem 'minitest-rg'
+  gem 'rails-controller-testing'
+  gem 'rubocop'
+  gem 'chandler', '0.9.0'
+end

--- a/test/rails_50/Gemfile
+++ b/test/rails_50/Gemfile
@@ -2,10 +2,12 @@ source 'https://rubygems.org'
 
 gemspec :path => '../..'
 
-gem 'rails', '~> 5.0.a'
+group :development do
+  gem 'rails', '~> 5.0.a'
 
-gem 'mocha'
-gem 'minitest-rg'
-gem 'rails-controller-testing'
-gem 'rubocop'
-gem 'chandler', '0.9.0'
+  gem 'mocha'
+  gem 'minitest-rg'
+  gem 'rails-controller-testing'
+  gem 'rubocop'
+  gem 'chandler', '0.9.0'
+end

--- a/test/rails_51/Gemfile
+++ b/test/rails_51/Gemfile
@@ -2,10 +2,12 @@ source 'https://rubygems.org'
 
 gemspec :path => '../..'
 
-gem 'rails', '~> 5.1.a'
+group :development do
+  gem 'rails', '~> 5.1.a'
 
-gem 'mocha'
-gem 'minitest-rg'
-gem 'rails-controller-testing'
-gem 'rubocop'
-gem 'chandler', '0.9.0'
+  gem 'mocha'
+  gem 'minitest-rg'
+  gem 'rails-controller-testing'
+  gem 'rubocop'
+  gem 'chandler', '0.9.0'
+end

--- a/test/rails_60/Gemfile
+++ b/test/rails_60/Gemfile
@@ -2,10 +2,12 @@ source 'https://rubygems.org'
 
 gemspec :path => '../..'
 
-gem 'rails', '~> 6.0.a'
+group :development do
+  gem 'rails', '~> 6.0.a'
 
-gem 'mocha'
-gem 'minitest-rg'
-gem 'rails-controller-testing'
-gem 'rubocop'
-gem 'chandler', '0.9.0'
+  gem 'mocha'
+  gem 'minitest-rg'
+  gem 'rails-controller-testing'
+  gem 'rubocop'
+  gem 'chandler', '0.9.0'
+end


### PR DESCRIPTION
To teach dependabot that in the case of gems, everything in the Gemfile is a development dependency.

Hopefully adding this makes dependabot automerge PRs? If it doesn't, it's probably because of the compulsory review requirement as suggested by @timoschilling.