### PR TITLE
Drop ruby 2.3 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,36 +55,6 @@ version: 2.1
   - *run_tests
 
 jobs:
-  ruby23rails50:
-    docker:
-      - image: circleci/ruby:2.3.8
-
-    environment:
-      BUNDLE_GEMFILE: test/rails_50/Gemfile
-
-    steps:
-      *test_steps
-
-  ruby23rails51:
-    docker:
-      - image: circleci/ruby:2.3.8
-
-    environment:
-      BUNDLE_GEMFILE: test/rails_51/Gemfile
-
-    steps:
-      *test_steps
-
-  ruby23rails52:
-    docker:
-      - image: circleci/ruby:2.3.8
-
-    environment:
-      BUNDLE_GEMFILE: Gemfile
-
-    steps:
-      *test_steps
-
   ruby24rails50:
     docker:
       - image: circleci/ruby:2.4.5
@@ -195,39 +165,6 @@ jobs:
     steps:
       *test_steps
 
-  jruby91rails50:
-    docker:
-      - image: circleci/jruby:9.1.17.0
-
-    environment:
-      BUNDLE_GEMFILE: test/rails_50/Gemfile
-      JRUBY_OPTS: -J-Xmx1024m --dev --debug
-
-    steps:
-      *test_steps
-
-  jruby91rails51:
-    docker:
-      - image: circleci/jruby:9.1.17.0
-
-    environment:
-      BUNDLE_GEMFILE: test/rails_51/Gemfile
-      JRUBY_OPTS: -J-Xmx1024m --dev --debug
-
-    steps:
-      *test_steps
-
-  jruby91rails52:
-    docker:
-      - image: circleci/jruby:9.1.17.0
-
-    environment:
-      BUNDLE_GEMFILE: Gemfile
-      JRUBY_OPTS: -J-Xmx1024m --dev --debug
-
-    steps:
-      *test_steps
-
   jruby92rails50:
     docker:
       - image: circleci/jruby:9.2.6.0
@@ -277,11 +214,6 @@ workflows:
 
   build:
     jobs:
-      # Ruby 2.3
-      - ruby23rails50
-      - ruby23rails51
-      - ruby23rails52
-
       # Ruby 2.4
       - ruby24rails50
       - ruby24rails51
@@ -298,11 +230,6 @@ workflows:
       - ruby26rails51
       - ruby26rails52
       - ruby26rails60
-
-      # JRuby 9.1.7
-      - jruby91rails50
-      - jruby91rails51
-      - jruby91rails52
 
       # JRuby 9.2.0
       - jruby92rails50

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
 
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Metrics:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master (unreleased)
 
+* Remove support for Ruby `< 2.4`.
+
 # Version 1.10.0
 
 _No changes_.

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files         = Dir["app/**/*", "lib/**/*", "README.md", "MIT-LICENSE"]
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.4'
 
   s.add_dependency("responders", "~> 2.0")
   s.add_dependency("actionpack", ">= 5.0", "< 6.1")


### PR DESCRIPTION
So we get in line with activeadmin, and reduce the size of the CI matrix. And because 2.3 already reached its end of life.