### PR TITLE
Get ready for 1.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (unreleased)
 
+* Add support for responders `>= 3.0`.
 * Remove support for Ruby `< 2.4`.
 
 ## Version 1.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (unreleased)
 
+## Version 1.11.0
+
 * Add support for responders `>= 3.0`.
 * Remove support for Ruby `< 2.4`.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    inherited_resources (1.10.0)
+    inherited_resources (1.11.0)
       actionpack (>= 5.0, < 6.1)
       has_scope (~> 0.6)
       railties (>= 5.0, < 6.1)

--- a/lib/inherited_resources/version.rb
+++ b/lib/inherited_resources/version.rb
@@ -1,3 +1,3 @@
 module InheritedResources
-  VERSION = '1.10.0'.freeze
+  VERSION = '1.11.0'.freeze
 end

--- a/test/rails_50/Gemfile.lock
+++ b/test/rails_50/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    inherited_resources (1.10.0)
+    inherited_resources (1.11.0)
       actionpack (>= 5.0, < 6.1)
       has_scope (~> 0.6)
       railties (>= 5.0, < 6.1)

--- a/test/rails_51/Gemfile.lock
+++ b/test/rails_51/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    inherited_resources (1.10.0)
+    inherited_resources (1.11.0)
       actionpack (>= 5.0, < 6.1)
       has_scope (~> 0.6)
       railties (>= 5.0, < 6.1)

--- a/test/rails_60/Gemfile.lock
+++ b/test/rails_60/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    inherited_resources (1.10.0)
+    inherited_resources (1.11.0)
       actionpack (>= 5.0, < 6.1)
       has_scope (~> 0.6)
       railties (>= 5.0, < 6.1)


### PR DESCRIPTION
Essentially so that people can use responders 3.0 without getting dependency conflicts.