### PR TITLE
Let Dependabot always handle security updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,7 +10,7 @@ update_configs:
 
     allowed_updates:
       - match:
-          dependency_type: production
+          dependency_type: all
           update_type: security
 
     automerged_updates:
@@ -25,7 +25,7 @@ update_configs:
 
     allowed_updates:
       - match:
-          dependency_type: production
+          dependency_type: all
           update_type: security
 
     automerged_updates:
@@ -40,7 +40,7 @@ update_configs:
 
     allowed_updates:
       - match:
-          dependency_type: production
+          dependency_type: all
           update_type: security
 
     automerged_updates:
@@ -55,7 +55,7 @@ update_configs:
 
     allowed_updates:
       - match:
-          dependency_type: production
+          dependency_type: all
           update_type: security
 
     automerged_updates:


### PR DESCRIPTION
Dependabot doesn't currently create PRs for security updates if they are indirect production (runtime) dependencies (not direct dependencies of the gem, but dependencies of a runtime dependency). Like nokogiri here.
    
Since Github still creates security alerts for those, I'd like dependabot to handle these automatically too.
    
My guess is that dependabot classifies dependency types like this:
    
    ▾ all
    ├── ▾ direct
    │   ├── production
    │   └── development
    └── indirect
    
And not like this as I thought:
    
    ▾ all
    ├── ▾ production
    │   ├── direct
    │   └── indirect
    └── ▾ development
        ├── direct
        └── indirect
    
So specifying `type: production` won't suffice for this type of dependencies. Let's try with `type: all`.