### PR TITLE
Fix dependabot configuration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,11 +8,6 @@ update_configs:
     update_schedule: live
     version_requirement_updates: increase_versions_if_necessary
 
-    allowed_updates:
-      - match:
-          dependency_type: all
-          update_type: security
-
     automerged_updates:
       - match:
           dependency_type: development
@@ -22,11 +17,6 @@ update_configs:
     directory: /test/rails_52
     update_schedule: live
     version_requirement_updates: increase_versions_if_necessary
-
-    allowed_updates:
-      - match:
-          dependency_type: all
-          update_type: security
 
     automerged_updates:
       - match:


### PR DESCRIPTION
`automerged_updates` should be a subset of `allowed_updates`, and we were only considering security dependencies in `allowed_updates`, so basically `automerged_updates` was being ignored.