### PR TITLE
Add rails_61 to Dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -14,6 +14,16 @@ update_configs:
           update_type: all
 
   - package_manager: ruby:bundler
+    directory: /test/rails_61
+    update_schedule: live
+    version_requirement_updates: increase_versions_if_necessary
+
+    automerged_updates:
+      - match:
+          dependency_type: development
+          update_type: all
+
+  - package_manager: ruby:bundler
     directory: /test/rails_52
     update_schedule: live
     version_requirement_updates: increase_versions_if_necessary


### PR DESCRIPTION
This updates our Dependabot config to include our Rails 6.1 gemfile as I noticed that was missing but we should have it to stay in sync.