### PR TITLE
Drop support for Ruby 2.5

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,9 +6,6 @@ pull_request_rules:
     conditions:
       - author~=^dependabot(|-preview)\[bot\]$
       - check-success=lint
-      - check-success=test(ruby-2.5, rails_52)
-      - check-success=test(ruby-2.5, rails_60)
-      - check-success=test(ruby-2.5, rails_61)
       - check-success=test(ruby-2.6, rails_52)
       - check-success=test(ruby-2.6, rails_60)
       - check-success=test(ruby-2.6, rails_61)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,6 @@ jobs:
 
       matrix:
         ruby:
-          - { name: ruby-2.5, value: 2.5.9 }
           - { name: ruby-2.6, value: 2.6.9 }
           - { name: ruby-2.7, value: 2.7.5 }
           - { name: ruby-3.0, value: 3.0.3 }
@@ -56,8 +55,6 @@ jobs:
         rails: [rails_52, rails_60, rails_61, rails_70]
 
         exclude:
-          - ruby: { name: ruby-2.5, value: 2.5.9 }
-            rails: rails_70
           - ruby: { name: ruby-2.6, value: 2.6.9 }
             rails: rails_70
           - ruby: { name: ruby-2.7, value: 2.7.5 }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
 
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Metrics:
   Enabled: false

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files         = Dir["app/**/*", "lib/**/*", "README.md", "MIT-LICENSE"]
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.6'
 
   s.add_dependency("responders", ">= 2", "< 4")
   s.add_dependency("actionpack", ">= 5.2", "< 7.1")


### PR DESCRIPTION
Ruby 2.5 arrived to EOL more than 8 months ago. I think we can remove it from the test matrix and drop the support.