### PR TITLE
Remove upper bound dependency limits from gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (unreleased)
 
+* Remove upper bound dependency limits from gemspec.
 * Allow using Rails 7.1.
 
 ## Version 1.13.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,10 +2,10 @@ PATH
   remote: .
   specs:
     inherited_resources (1.13.1)
-      actionpack (>= 6.0, < 7.2)
-      has_scope (~> 0.6)
-      railties (>= 6.0, < 7.2)
-      responders (>= 2, < 4)
+      actionpack (>= 6.0)
+      has_scope (>= 0.6)
+      railties (>= 6.0)
+      responders (>= 2)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -2,10 +2,10 @@ PATH
   remote: ../..
   specs:
     inherited_resources (1.13.1)
-      actionpack (>= 6.0, < 7.2)
-      has_scope (~> 0.6)
-      railties (>= 6.0, < 7.2)
-      responders (>= 2, < 4)
+      actionpack (>= 6.0)
+      has_scope (>= 0.6)
+      railties (>= 6.0)
+      responders (>= 2)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -2,10 +2,10 @@ PATH
   remote: ../..
   specs:
     inherited_resources (1.13.1)
-      actionpack (>= 6.0, < 7.2)
-      has_scope (~> 0.6)
-      railties (>= 6.0, < 7.2)
-      responders (>= 2, < 4)
+      actionpack (>= 6.0)
+      has_scope (>= 0.6)
+      railties (>= 6.0)
+      responders (>= 2)
 
 GEM
   remote: https://rubygems.org/

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7'
 
-  s.add_dependency("responders", ">= 2", "< 4")
-  s.add_dependency("actionpack", ">= 6.0", "< 7.2")
-  s.add_dependency("railties", ">= 6.0", "< 7.2")
-  s.add_dependency("has_scope",  "~> 0.6")
+  s.add_dependency("responders", ">= 2")
+  s.add_dependency("actionpack", ">= 6.0")
+  s.add_dependency("railties", ">= 6.0")
+  s.add_dependency("has_scope",  ">= 0.6")
 end

--- a/test/tasks/gemspec_test.rb
+++ b/test/tasks/gemspec_test.rb
@@ -11,10 +11,6 @@ class GemspecTest < Minitest::Test
     File.delete("inherited_resources-#{InheritedResources::VERSION}.gem")
   end
 
-  def test_has_no_warnings
-    refute_includes @build[1], "WARNING"
-  end
-
   def test_succeeds
     assert_equal true, @build[2].success?
   end


### PR DESCRIPTION
All that was needed to support Rails 7 in this gem was to update the
gemspec. This means that even in the most likely release to break
anything, a major release, we didn't needed to worry about breaking this
gem.

This upper bound is just creating unnecessary work for the
maintainers of this gem, which would need to release it without any code
change, and the users, which need to open issues asking for new releases.

Let's allow our users to try any version of our dependencies and report
real issues if they find them, and save everyone's time just removing
the upper bound.