### PR TITLE
Use `action_controller_base` hook

### DIFF
--- a/lib/inherited_resources.rb
+++ b/lib/inherited_resources.rb
@@ -25,16 +25,13 @@ module InheritedResources
   end
 end
 
-ActiveSupport.on_load(:action_controller) do
-  # We can remove this check and change to `on_load(:action_controller_base)` in Rails 5.2.
-  if self == ActionController::Base
-    # If you cannot inherit from InheritedResources::Base you can call
-    # inherit_resources in your controller to have all the required modules and
-    # funcionality included.
-    def self.inherit_resources
-      InheritedResources::Base.inherit_resources(self)
-      initialize_resources_class_accessors!
-      create_resources_url_helpers!
-    end
+ActiveSupport.on_load(:action_controller_base) do
+  # If you cannot inherit from InheritedResources::Base you can call
+  # inherit_resources in your controller to have all the required modules and
+  # funcionality included.
+  def self.inherit_resources
+    InheritedResources::Base.inherit_resources(self)
+    initialize_resources_class_accessors!
+    create_resources_url_helpers!
   end
 end


### PR DESCRIPTION
Remove a check needed by Rails 5.1 and use `action_controller_base`
hook, available from Rails 5.2

Ref:
- 4cc8ced1f7083d5f03c32777eb66333453da62d7
- #536
- rails/rails#28402