### PR TITLE
Stop testing on JRuby

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,8 +15,6 @@ pull_request_rules:
       - check-success=test(ruby-3.1, rails_60)
       - check-success=test(ruby-3.1, rails_61)
       - check-success=test(ruby-3.1, rails_70)
-      - check-success=test(jruby-9.3, rails_60)
-      - check-success=test(jruby-9.3, rails_61)
 
     actions:
       merge:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,13 +50,8 @@ jobs:
           - { name: ruby-2.7, value: 2.7.5 }
           - { name: ruby-3.0, value: 3.0.3 }
           - { name: ruby-3.1, value: 3.1.0 }
-          - { name: jruby-9.3, value: jruby-9.3.2.0 }
 
         rails: [rails_60, rails_61, rails_70]
-
-        exclude:
-          - ruby: { name: jruby-9.3, value: jruby-9.3.2.0 }
-            rails: rails_70
 
     env:
       COVERAGE: true


### PR DESCRIPTION
JRuby is not yet compatible with Ruby 2.7.0, and that's the oldest MRI version that we officially support.