### PR TITLE
Add frozen_string_literal magic comments

### DIFF
--- a/lib/generators/rails/inherited_resources_controller_generator.rb
+++ b/lib/generators/rails/inherited_resources_controller_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails/generators/rails/scaffold_controller/scaffold_controller_generator'
 
 module Rails

--- a/lib/inherited_resources.rb
+++ b/lib/inherited_resources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This is here because responders don't require it.
 require 'rails/engine'
 require 'responders'

--- a/lib/inherited_resources/actions.rb
+++ b/lib/inherited_resources/actions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InheritedResources
   # Holds all default actions for InheritedResouces.
   module Actions

--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Whenever base is required load the dumb responder since it's used inside actions.
 require 'inherited_resources/blank_slate'
 

--- a/lib/inherited_resources/belongs_to_helpers.rb
+++ b/lib/inherited_resources/belongs_to_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InheritedResources
 
   # = belongs_to

--- a/lib/inherited_resources/blank_slate.rb
+++ b/lib/inherited_resources/blank_slate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InheritedResources
   # An object from BlankSlate simply discards all messages sent to it.
   class BlankSlate

--- a/lib/inherited_resources/class_methods.rb
+++ b/lib/inherited_resources/class_methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InheritedResources
   module ClassMethods
 

--- a/lib/inherited_resources/dsl.rb
+++ b/lib/inherited_resources/dsl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InheritedResources
   # Allows controllers to write actions using a class method DSL.
   #

--- a/lib/inherited_resources/engine.rb
+++ b/lib/inherited_resources/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InheritedResources
   class Railtie < ::Rails::Engine
     config.inherited_resources = InheritedResources

--- a/lib/inherited_resources/polymorphic_helpers.rb
+++ b/lib/inherited_resources/polymorphic_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InheritedResources
 
   # = polymorphic associations

--- a/lib/inherited_resources/responder.rb
+++ b/lib/inherited_resources/responder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InheritedResources
   class Responder < ActionController::Responder
     include Responders::FlashResponder

--- a/lib/inherited_resources/shallow_helpers.rb
+++ b/lib/inherited_resources/shallow_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InheritedResources
   # Shallow provides a functionality that goes on pair with Rails' shallow.
   # It is very similar to "optional" but it actually finds all the parents

--- a/lib/inherited_resources/singleton_helpers.rb
+++ b/lib/inherited_resources/singleton_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InheritedResources
 
   # = singleton

--- a/lib/inherited_resources/url_helpers.rb
+++ b/lib/inherited_resources/url_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InheritedResources
   # = URLHelpers
   #


### PR DESCRIPTION
I spotted this while profiling my app with memory_profiler. InheritedResouces::UrlHelpers#define_params_helper showed up, where it allocated some 12320 blank strings (`''`).

It isn't much relatively by itself, but it adds up.