### PR TITLE
update responders config to match default error_status & redirect_status codes for current rails version

### DIFF
--- a/lib/inherited_resources/responder.rb
+++ b/lib/inherited_resources/responder.rb
@@ -1,5 +1,10 @@
 module InheritedResources
   class Responder < ActionController::Responder
     include Responders::FlashResponder
+    include Responders::HttpCacheResponder
+  
+    # Configure default status codes for responding to errors and redirects.
+    self.error_status = :unprocessable_entity
+    self.redirect_status = :see_other
   end
 end

--- a/test/aliases_test.rb
+++ b/test/aliases_test.rb
@@ -100,7 +100,7 @@ class AliasesTest < ActionController::TestCase
     Student.stubs(:new).returns(mock_student(save: false, errors: {some: :error}))
     @controller.stubs(:resource_url).returns('http://test.host/')
     post :create
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_equal "New HTML", @response.body.strip
   end
 
@@ -109,7 +109,7 @@ class AliasesTest < ActionController::TestCase
     Student.stubs(:new).returns(mock_student(save: false, errors: {some: :error}))
     @controller.stubs(:resource_url).returns('http://test.host/')
     post :create
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_equal "New HTML", @response.body.strip
   end
 

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -222,7 +222,7 @@ class CreateActionBaseTest < ActionController::TestCase
   def test_render_new_template_when_user_cannot_be_saved
     User.stubs(:new).returns(mock_user(save: false, errors: {some: :error}))
     post :create
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_equal "New HTML", @response.body.strip
   end
 
@@ -289,7 +289,7 @@ class UpdateActionBaseTest < ActionController::TestCase
   def test_render_edit_template_when_user_cannot_be_saved
     User.stubs(:find).returns(mock_user(update: false, errors: {some: :error}))
     put :update, params: { id: '42' }
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_equal "Edit HTML", @response.body.strip
   end
 

--- a/test/customized_base_test.rb
+++ b/test/customized_base_test.rb
@@ -130,7 +130,7 @@ class CreateActionCustomizedBaseTest < ActionController::TestCase
   def test_render_new_template_when_user_cannot_be_saved
     Car.stubs(:create_new).returns(mock_car(save_successfully: false, errors: {some: :error}))
     post :create
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_equal "New HTML", @response.body.strip
   end
 end
@@ -155,7 +155,7 @@ class UpdateActionCustomizedBaseTest < ActionController::TestCase
   def test_render_edit_template_when_user_cannot_be_saved
     Car.stubs(:get).returns(mock_car(update_successfully: false, errors: {some: :error}))
     put :update, params: { id: '42' }
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_equal "Edit HTML", @response.body.strip
   end
 end


### PR DESCRIPTION
Update responder class to the current defaults for responder gem. 

Fixes #862