### PR TITLE
Fix test suite deprecations caused by Rails 7.1

### DIFF
--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -65,6 +65,10 @@ module UserTestHelper
         user
       end
     end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
+    end
 end
 
 class IndexActionBaseTest < ActionController::TestCase
@@ -181,21 +185,21 @@ class CreateActionBaseTest < ActionController::TestCase
   include UserTestHelper
 
   def test_expose_a_newly_create_user_when_saved_with_success
-    User.expects(:new).with({'these' => 'params'}).returns(mock_user(save: true))
+    User.expects(:new).with(build_parameters({'these' => 'params'})).returns(mock_user(save: true))
     post :create, params: { user: {these: 'params'} }
     assert_equal mock_user, assigns(:user)
   end
 
   def test_expose_a_newly_create_user_when_saved_with_success_and_role_setted
     @controller.class.send(:with_role, :admin)
-    User.expects(:new).with({'these' => 'params'}, {as: :admin}).returns(mock_user(save: true))
+    User.expects(:new).with(build_parameters({'these' => 'params'}), {as: :admin}).returns(mock_user(save: true))
     post :create, params: { user: {these: 'params'} }
     assert_equal mock_user, assigns(:user)
   end
 
   def test_expose_a_newly_create_user_when_saved_with_success_and_without_protection_setted
     @controller.class.send(:without_protection, true)
-    User.expects(:new).with({'these' => 'params'}, {without_protection: true}).returns(mock_user(save: true))
+    User.expects(:new).with(build_parameters({'these' => 'params'}), {without_protection: true}).returns(mock_user(save: true))
     post :create, params: { user: {these: 'params'} }
     assert_equal mock_user, assigns(:user)
   end
@@ -238,7 +242,7 @@ class UpdateActionBaseTest < ActionController::TestCase
 
   def test_update_the_requested_object
     User.expects(:find).with('42').returns(mock_user)
-    mock_user.expects(:update).with({'these' => 'params'}).returns(true)
+    mock_user.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: '42', user: {these: 'params'} }
     assert_equal mock_user, assigns(:user)
   end
@@ -246,7 +250,7 @@ class UpdateActionBaseTest < ActionController::TestCase
   def test_update_the_requested_object_when_setted_role
     @controller.class.send(:with_role, :admin)
     User.expects(:find).with('42').returns(mock_user)
-    mock_user.expects(:update).with({'these' => 'params'}, {as: :admin}).returns(true)
+    mock_user.expects(:update).with(build_parameters({'these' => 'params'}), {as: :admin}).returns(true)
     put :update, params: { id: '42', user: {these: 'params'} }
     assert_equal mock_user, assigns(:user)
   end
@@ -254,7 +258,7 @@ class UpdateActionBaseTest < ActionController::TestCase
   def test_update_the_requested_object_when_setted_without_protection
     @controller.class.send(:without_protection, true)
     User.expects(:find).with('42').returns(mock_user)
-    mock_user.expects(:update).with({'these' => 'params'}, {without_protection: true}).returns(true)
+    mock_user.expects(:update).with(build_parameters({'these' => 'params'}), {without_protection: true}).returns(true)
     put :update, params: { id: '42', user: {these: 'params'} }
     assert_equal mock_user, assigns(:user)
   end

--- a/test/belongs_to_test.rb
+++ b/test/belongs_to_test.rb
@@ -57,7 +57,7 @@ class BelongsToTest < ActionController::TestCase
   end
 
   def test_expose_a_newly_create_comment_on_create
-    Comment.expects(:build).with({'these' => 'params'}).returns(mock_comment(save: true))
+    Comment.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_comment(save: true))
     post :create, params: { post_id: '37', comment: {these: 'params'} }
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
@@ -65,7 +65,7 @@ class BelongsToTest < ActionController::TestCase
 
   def test_update_the_requested_object_on_update
     Comment.expects(:find).with('42').returns(mock_comment)
-    mock_comment.expects(:update).with({'these' => 'params'}).returns(true)
+    mock_comment.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: '42', post_id: '37', comment: {these: 'params'} }
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
@@ -103,6 +103,10 @@ class BelongsToTest < ActionController::TestCase
     def mock_comment(stubs={})
       @mock_comment ||= mock(stubs)
     end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
+    end
 end
 
 class Reply
@@ -132,7 +136,7 @@ class BelongsToWithRedirectsTest < ActionController::TestCase
 
   def test_redirect_to_the_post_on_create_if_show_and_index_undefined
     @controller.expects(:parent_url).returns('http://test.host/')
-    Reply.expects(:build).with({'these' => 'params'}).returns(mock_reply(save: true))
+    Reply.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_reply(save: true))
     post :create, params: { post_id: '37', reply: { these: 'params' } }
     assert_redirected_to 'http://test.host/'
   end
@@ -160,5 +164,9 @@ class BelongsToWithRedirectsTest < ActionController::TestCase
 
     def mock_reply(stubs={})
       @mock_reply ||= mock(stubs)
+    end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
     end
 end

--- a/test/belongs_to_with_shallow_test.rb
+++ b/test/belongs_to_with_shallow_test.rb
@@ -45,7 +45,7 @@ class BelongsToWithShallowTest < ActionController::TestCase
   end
 
   def test_expose_a_newly_create_tag_on_create
-    Tag.expects(:build).with({'these' => 'params'}).returns(mock_tag(save: true))
+    Tag.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_tag(save: true))
     post :create, params: { post_id: 'thirty_seven', tag: {these: 'params'} }
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)
@@ -67,7 +67,7 @@ class BelongsToWithShallowTest < ActionController::TestCase
 
   def test_update_the_requested_object_on_update
     should_find_parents
-    mock_tag.expects(:update).with({'these' => 'params'}).returns(true)
+    mock_tag.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: '42', tag: {these: 'params'} }
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)
@@ -95,5 +95,9 @@ class BelongsToWithShallowTest < ActionController::TestCase
 
     def mock_tag(stubs={})
       @mock_tag ||= mock(stubs)
+    end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
     end
 end

--- a/test/customized_base_test.rb
+++ b/test/customized_base_test.rb
@@ -68,6 +68,10 @@ module CarTestHelper
         car
       end
     end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
+    end
 end
 
 class IndexActionCustomizedBaseTest < ActionController::TestCase
@@ -115,7 +119,7 @@ class CreateActionCustomizedBaseTest < ActionController::TestCase
   include CarTestHelper
 
   def test_expose_a_newly_create_user_when_saved_with_success
-    Car.expects(:create_new).with({'these' => 'params'}).returns(mock_car(save_successfully: true))
+    Car.expects(:create_new).with(build_parameters({'these' => 'params'})).returns(mock_car(save_successfully: true))
     post :create, params: { car: {these: 'params'} }
     assert_equal mock_car, assigns(:car)
   end
@@ -140,7 +144,7 @@ class UpdateActionCustomizedBaseTest < ActionController::TestCase
 
   def test_update_the_requested_object
     Car.expects(:get).with('42').returns(mock_car)
-    mock_car.expects(:update_successfully).with({'these' => 'params'}).returns(true)
+    mock_car.expects(:update_successfully).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: '42', car: {these: 'params'} }
     assert_equal mock_car, assigns(:car)
   end

--- a/test/defaults_test.rb
+++ b/test/defaults_test.rb
@@ -53,14 +53,14 @@ class DefaultsTest < ActionController::TestCase
   end
 
   def test_expose_a_newly_create_painter_when_saved_with_success
-    Malarz.expects(:new).with({'these' => 'params'}).returns(mock_painter(save: true))
+    Malarz.expects(:new).with(build_parameters({'these' => 'params'})).returns(mock_painter(save: true))
     post :create, params: { malarz: {these: 'params'} }
     assert_equal mock_painter, assigns(:malarz)
   end
 
   def test_update_the_requested_object
     Malarz.expects(:find_by_slug).with('forty_two').returns(mock_painter)
-    mock_painter.expects(:update).with({'these' => 'params'}).returns(true)
+    mock_painter.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: 'forty_two', malarz: {these: 'params'} }
     assert_equal mock_painter, assigns(:malarz)
   end
@@ -76,6 +76,10 @@ class DefaultsTest < ActionController::TestCase
 
     def mock_painter(stubs={})
       @mock_painter ||= mock(stubs)
+    end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
     end
 end
 
@@ -128,14 +132,14 @@ class DefaultsNamespaceTest < ActionController::TestCase
   end
 
   def test_expose_a_newly_create_lecturer_when_saved_with_success
-    Lecturer.expects(:new).with({'these' => 'params'}).returns(mock_lecturer(save: true))
+    Lecturer.expects(:new).with(build_parameters({'these' => 'params'})).returns(mock_lecturer(save: true))
     post :create, params: { lecturer: {these: 'params'} }
     assert_equal mock_lecturer, assigns(:lecturer)
   end
 
   def test_update_the_lecturer
     Lecturer.expects(:find_by_slug).with('forty_two').returns(mock_lecturer)
-    mock_lecturer.expects(:update).with({'these' => 'params'}).returns(true)
+    mock_lecturer.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: 'forty_two', lecturer: {these: 'params'} }
     assert_equal mock_lecturer, assigns(:lecturer)
   end
@@ -151,6 +155,10 @@ class DefaultsNamespaceTest < ActionController::TestCase
 
     def mock_lecturer(stubs={})
       @mock_lecturer ||= mock(stubs)
+    end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
     end
 end
 

--- a/test/multiple_nested_optional_belongs_to_test.rb
+++ b/test/multiple_nested_optional_belongs_to_test.rb
@@ -216,7 +216,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
   def test_expose_a_newly_created_project_with_student
     Student.expects(:find).with('37').returns(mock_student)
     mock_student.expects(:projects).returns(Project)
-    Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project(save: true))
+    Project.expects(:build).with(build_parameters({ 'these' => 'params' })).returns(mock_project(save: true))
     post :create, params: { student_id: '37', project: { these: 'params' } }
     assert_equal mock_student, assigns(:student)
     assert_equal mock_project, assigns(:project)
@@ -225,7 +225,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
   def test_expose_a_newly_created_project_with_manager
     Manager.expects(:find).with('37').returns(mock_manager)
     mock_manager.expects(:projects).returns(Project)
-    Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project(save: true))
+    Project.expects(:build).with(build_parameters({ 'these' => 'params' })).returns(mock_project(save: true))
     post :create, params: { manager_id: '37', project: { these: 'params' } }
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_project, assigns(:project)
@@ -234,7 +234,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
   def test_expose_a_newly_created_project_with_employee
     Employee.expects(:find).with('37').returns(mock_employee)
     mock_employee.expects(:projects).returns(Project)
-    Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project(save: true))
+    Project.expects(:build).with(build_parameters({ 'these' => 'params' })).returns(mock_project(save: true))
     post :create, params: { employee_id: '37', project: { these: 'params' } }
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
@@ -245,7 +245,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_manager.expects(:employees).returns(Employee)
     Employee.expects(:find).with('42').returns(mock_employee)
     mock_employee.expects(:projects).returns(Project)
-    Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project(save: true))
+    Project.expects(:build).with(build_parameters({ 'these' => 'params' })).returns(mock_project(save: true))
     post :create, params: { manager_id: '37', employee_id: '42', project: { these: 'params' } }
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_employee, assigns(:employee)
@@ -253,7 +253,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
   end
 
   def test_expose_a_newly_created_project_without_parents
-    Project.expects(:new).with({ 'these' => 'params' }).returns(mock_project(save: true))
+    Project.expects(:new).with(build_parameters({ 'these' => 'params' })).returns(mock_project(save: true))
     post :create, params: { project: { these: 'params' } }
     assert_equal mock_project, assigns(:project)
   end
@@ -263,7 +263,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     Student.expects(:find).with('37').returns(mock_student)
     mock_student.expects(:projects).returns(Project)
     Project.expects(:find).with('42').returns(mock_project)
-    mock_project.expects(:update).with({ 'these' => 'params' }).returns(true)
+    mock_project.expects(:update).with(build_parameters({ 'these' => 'params' })).returns(true)
     put :update, params: { id: '42', student_id: '37', project: { these: 'params' } }
     assert_equal mock_student, assigns(:student)
     assert_equal mock_project, assigns(:project)
@@ -273,7 +273,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     Manager.expects(:find).with('37').returns(mock_manager)
     mock_manager.expects(:projects).returns(Project)
     Project.expects(:find).with('42').returns(mock_project)
-    mock_project.expects(:update).with({ 'these' => 'params' }).returns(true)
+    mock_project.expects(:update).with(build_parameters({ 'these' => 'params' })).returns(true)
     put :update, params: { id: '42', manager_id: '37', project: { these: 'params' } }
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_project, assigns(:project)
@@ -283,7 +283,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     Employee.expects(:find).with('37').returns(mock_employee)
     mock_employee.expects(:projects).returns(Project)
     Project.expects(:find).with('42').returns(mock_project)
-    mock_project.expects(:update).with({ 'these' => 'params' }).returns(true)
+    mock_project.expects(:update).with(build_parameters({ 'these' => 'params' })).returns(true)
     put :update, params: { id: '42', employee_id: '37', project: { these: 'params' } }
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
@@ -295,7 +295,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     Employee.expects(:find).with('13').returns(mock_employee)
     mock_employee.expects(:projects).returns(Project)
     Project.expects(:find).with('42').returns(mock_project)
-    mock_project.expects(:update).with({ 'these' => 'params' }).returns(true)
+    mock_project.expects(:update).with(build_parameters({ 'these' => 'params' })).returns(true)
     put :update, params: { id: '42', manager_id: '37', employee_id: '13', project: { these: 'params' } }
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_employee, assigns(:employee)
@@ -374,5 +374,9 @@ class MultipleNestedOptionalTest < ActionController::TestCase
 
     def mock_project(stubs={})
       @mock_project ||= mock(stubs)
+    end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
     end
 end

--- a/test/nested_belongs_to_test.rb
+++ b/test/nested_belongs_to_test.rb
@@ -71,7 +71,7 @@ class NestedBelongsToTest < ActionController::TestCase
   end
 
   def test_assigns_country_and_state_and_city_on_create
-    City.expects(:build).with({'these' => 'params'}).returns(mock_city)
+    City.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_city)
     mock_city.expects(:save).returns(true)
     post :create, params: { state_id: '37', country_id: '13', city: {these: 'params'} }
 
@@ -112,5 +112,9 @@ class NestedBelongsToTest < ActionController::TestCase
 
     def mock_city(stubs={})
       @mock_city ||= mock(stubs)
+    end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
     end
 end

--- a/test/nested_belongs_to_with_shallow_test.rb
+++ b/test/nested_belongs_to_with_shallow_test.rb
@@ -76,7 +76,7 @@ class NestedBelongsToWithShallowTest < ActionController::TestCase
   def test_assigns_dresser_and_shelf_and_plate_on_create
     Shelf.expects(:find).with('37').twice.returns(mock_shelf)
 
-    Plate.expects(:build).with({'these' => 'params'}).returns(mock_plate)
+    Plate.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_plate)
     mock_plate.expects(:save).returns(true)
     post :create, params: { shelf_id: '37', plate: {these: 'params'} }
 
@@ -125,5 +125,9 @@ class NestedBelongsToWithShallowTest < ActionController::TestCase
 
     def mock_plate(stubs={})
       @mock_plate ||= mock(stubs)
+    end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
     end
 end

--- a/test/nested_model_with_shallow_test.rb
+++ b/test/nested_model_with_shallow_test.rb
@@ -64,14 +64,14 @@ class NestedModelWithShallowTest < ActionController::TestCase
 
   def test_expose_a_newly_create_group_with_speciality
     Speciality.expects(:find).with('37').twice.returns(mock_speciality)
-    Plan::Group.expects(:build).with({'these' => 'params'}).returns(mock_group(save: true))
+    Plan::Group.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_group(save: true))
     post :create, params: { speciality_id: '37', group: {'these' => 'params'} }
     assert_equal mock_group, assigns(:group)
   end
 
   def test_expose_a_update_group_with_speciality
     should_find_parents
-    mock_group.expects(:update).with('these' => 'params').returns(true)
+    mock_group.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     post :update, params: { id: 'forty_two', group: {'these' => 'params'} }
     assert_equal mock_group, assigns(:group)
   end
@@ -96,6 +96,10 @@ class NestedModelWithShallowTest < ActionController::TestCase
 
     def mock_subfaculty(stubs={})
       @mock_subfaculty ||= mock(stubs)
+    end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
     end
 end
 

--- a/test/nested_singleton_test.rb
+++ b/test/nested_singleton_test.rb
@@ -128,7 +128,7 @@ class NestedSingletonTest < ActionController::TestCase
   def test_expose_a_newly_create_address_on_create
     Party.expects(:find).with('37').returns(mock_party)
     mock_party.expects(:venue).returns(mock_venue)
-    mock_venue.expects(:build_address).with({'these' => 'params'}).returns(mock_address(save: true))
+    mock_venue.expects(:build_address).with(build_parameters({'these' => 'params'})).returns(mock_address(save: true))
     post :create, params: { party_id: '37', address: {these: 'params'} }
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
@@ -138,7 +138,7 @@ class NestedSingletonTest < ActionController::TestCase
   def test_update_the_requested_object_on_update
     Party.expects(:find).with('37').returns(mock_party)
     mock_party.expects(:venue).returns(mock_venue(address: mock_address))
-    mock_address.expects(:update).with({'these' => 'params'}).returns(mock_address(save: true))
+    mock_address.expects(:update).with(build_parameters({'these' => 'params'})).returns(mock_address(save: true))
     post :update, params: { party_id: '37', address: {these: 'params'} }
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
@@ -173,5 +173,9 @@ class NestedSingletonTest < ActionController::TestCase
 
     def mock_geolocation(stubs={})
       @mock_geolocation ||= mock('geolocation', stubs)
+    end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
     end
 end

--- a/test/optional_belongs_to_test.rb
+++ b/test/optional_belongs_to_test.rb
@@ -93,14 +93,14 @@ class OptionalTest < ActionController::TestCase
   def test_expose_a_newly_create_product_with_category
     Category.expects(:find).with('37').returns(mock_category)
     mock_category.expects(:products).returns(Product)
-    Product.expects(:build).with({'these' => 'params'}).returns(mock_product(save: true))
+    Product.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_product(save: true))
     post :create, params: { category_id: '37', product: {these: 'params'} }
     assert_equal mock_category, assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
 
   def test_expose_a_newly_create_product_without_category
-    Product.expects(:new).with({'these' => 'params'}).returns(mock_product(save: true))
+    Product.expects(:new).with(build_parameters({'these' => 'params'})).returns(mock_product(save: true))
     post :create, params: { product: {these: 'params'} }
     assert_nil assigns(:category)
     assert_equal mock_product, assigns(:product)
@@ -110,7 +110,7 @@ class OptionalTest < ActionController::TestCase
     Category.expects(:find).with('37').returns(mock_category)
     mock_category.expects(:products).returns(Product)
     Product.expects(:find).with('42').returns(mock_product)
-    mock_product.expects(:update).with({'these' => 'params'}).returns(true)
+    mock_product.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
 
     put :update, params: { id: '42', category_id: '37', product: {these: 'params'} }
     assert_equal mock_category, assigns(:category)
@@ -119,7 +119,7 @@ class OptionalTest < ActionController::TestCase
 
   def test_update_the_requested_object_without_category
     Product.expects(:find).with('42').returns(mock_product)
-    mock_product.expects(:update).with({'these' => 'params'}).returns(true)
+    mock_product.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
 
     put :update, params: { id: '42', product: {these: 'params'} }
     assert_nil assigns(:category)
@@ -168,5 +168,9 @@ class OptionalTest < ActionController::TestCase
 
     def mock_product(stubs={})
       @mock_product ||= mock(stubs)
+    end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
     end
 end

--- a/test/polymorphic_test.rb
+++ b/test/polymorphic_test.rb
@@ -71,7 +71,7 @@ class PolymorphicFactoriesTest < ActionController::TestCase
   end
 
   def test_expose_a_newly_create_employee_on_create
-    Employee.expects(:build).with({'these' => 'params'}).returns(mock_employee(save: true))
+    Employee.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_employee(save: true))
     post :create, params: { factory_id: '37', employee: {these: 'params'} }
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
@@ -79,7 +79,7 @@ class PolymorphicFactoriesTest < ActionController::TestCase
 
   def test_update_the_requested_object_on_update
     Employee.expects(:find).with('42').returns(mock_employee)
-    mock_employee.expects(:update).with({'these' => 'params'}).returns(true)
+    mock_employee.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: '42', factory_id: '37', employee: {these: 'params'} }
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
@@ -115,6 +115,10 @@ class PolymorphicFactoriesTest < ActionController::TestCase
 
     def mock_employee(stubs={})
       @mock_employee ||= mock(stubs)
+    end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
     end
 end
 
@@ -167,7 +171,7 @@ class PolymorphicCompanyTest < ActionController::TestCase
   end
 
   def test_expose_a_newly_create_employee_on_create
-    Employee.expects(:build).with({'these' => 'params'}).returns(mock_employee(save: true))
+    Employee.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_employee(save: true))
     post :create, params: { company_id: '37', employee: {these: 'params'} }
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)
@@ -175,7 +179,7 @@ class PolymorphicCompanyTest < ActionController::TestCase
 
   def test_update_the_requested_object_on_update
     Employee.expects(:find).with('42').returns(mock_employee)
-    mock_employee.expects(:update).with({'these' => 'params'}).returns(true)
+    mock_employee.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: '42', company_id: '37', employee: {these: 'params'} }
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)
@@ -211,6 +215,10 @@ class PolymorphicCompanyTest < ActionController::TestCase
 
     def mock_employee(stubs={})
       @mock_employee ||= mock(stubs)
+    end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
     end
 end
 

--- a/test/singleton_test.rb
+++ b/test/singleton_test.rb
@@ -58,7 +58,7 @@ class SingletonTest < ActionController::TestCase
 
   def test_expose_a_newly_create_manager_on_create
     Store.expects(:find).with('37').returns(mock_store)
-    mock_store.expects(:build_manager).with({'these' => 'params'}).returns(mock_manager(save: true))
+    mock_store.expects(:build_manager).with(build_parameters({'these' => 'params'})).returns(mock_manager(save: true))
     post :create, params: { store_id: '37', manager: {these: 'params'} }
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)
@@ -66,7 +66,7 @@ class SingletonTest < ActionController::TestCase
 
   def test_update_the_requested_object_on_update
     Store.expects(:find).with('37').returns(mock_store(manager: mock_manager))
-    mock_manager.expects(:update).with({'these' => 'params'}).returns(true)
+    mock_manager.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { store_id: '37', manager: {these: 'params'} }
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)
@@ -90,5 +90,9 @@ class SingletonTest < ActionController::TestCase
 
     def mock_manager(stubs={})
       @mock_manager ||= mock(stubs)
+    end
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
     end
 end

--- a/test/strong_parameters_test.rb
+++ b/test/strong_parameters_test.rb
@@ -128,23 +128,29 @@ class StrongParametersIntegrationTest < ActionController::TestCase
   end
 
   def test_permitted_params_from_new
-    Widget.expects(:new).with('permitted' => 'param')
+    Widget.expects(:new).with(build_parameters({'permitted' => 'param'}).permit!)
     get :new, params: { widget: { permitted: 'param', prohibited: 'param' } }
   end
 
   def test_permitted_params_from_create
-    Widget.expects(:new).with('permitted' => 'param').returns(mock(save: true))
+    Widget.expects(:new).with(build_parameters({'permitted' => 'param'}).permit!).returns(mock(save: true))
     post :create, params: { widget: { permitted: 'param', prohibited: 'param' } }
   end
 
   def test_permitted_params_from_update
     mock_widget = mock
     mock_widget.stubs(:class).returns(Widget)
-    mock_widget.expects(:update).with('permitted' => 'param')
+    mock_widget.expects(:update).with(build_parameters({'permitted' => 'param'}).permit!)
     mock_widget.stubs(:persisted?).returns(true)
     mock_widget.stubs(:to_model).returns(mock_widget)
     mock_widget.stubs(:model_name).returns(Widget.model_name)
     Widget.expects(:find).with('42').returns(mock_widget)
     put :update, params: { id: '42', widget: {permitted: 'param', prohibited: 'param'} }
   end
+
+  protected
+
+    def build_parameters(hash)
+      ActionController::Parameters.new(hash)
+    end
 end


### PR DESCRIPTION
In the following example:
```ruby
    Project.expects(:build).with({ 'these' => 'params' }).returns(mock_project(save: true))
    post :create, params: { student_id: '37', project: { these: 'params' } }
```
The `Project` instance was being mocked to expect `{ 'these' => 'params' }`, but when the code is being exercised, what comes is an `ActionController::Parameters` instance from the controller, so Mocha was comparing both to see if the expectation was being met, thus triggering the deprecated comparison between `ActionController::Parameters` and `Hash`.

This PR changes all problematic expectations to use `ActionController::Parameters` instead of hashes.

*There is another set of deprecations related to Mocha an positional arguments, but I think this PR is already pretty big, but if there is no problem, I can fix them here too.*