### PR TITLE
Add Rubocop Minitest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 ---
 
 require:
+  - rubocop-minitest
   - rubocop-performance
 
 AllCops:
@@ -44,6 +45,165 @@ Layout/TrailingWhitespace:
   Enabled: true
 
 Layout/TrailingEmptyLines:
+  Enabled: true
+
+Minitest:
+  Enabled: true
+
+Minitest/AssertEmpty:
+  Enabled: true
+
+Minitest/AssertEmptyLiteral:
+  Enabled: true
+
+Minitest/AssertEqual:
+  Enabled: true
+
+Minitest/AssertInDelta:
+  Enabled: true
+
+Minitest/AssertIncludes:
+  Enabled: true
+
+Minitest/AssertInstanceOf:
+  Enabled: true
+
+Minitest/AssertKindOf:
+  Enabled: true
+
+Minitest/AssertMatch:
+  Enabled: true
+
+Minitest/AssertNil:
+  Enabled: true
+
+Minitest/AssertOperator:
+  Enabled: true
+
+Minitest/AssertOutput:
+  Enabled: true
+
+Minitest/AssertPathExists:
+  Enabled: true
+
+Minitest/AssertPredicate:
+  Enabled: true
+
+Minitest/AssertRaisesCompoundBody:
+  Enabled: true
+
+Minitest/AssertRaisesWithRegexpArgument:
+  Enabled: true
+
+Minitest/AssertRespondTo:
+  Enabled: true
+
+Minitest/AssertSame:
+  Enabled: true
+
+Minitest/AssertSilent:
+  Enabled: true
+
+Minitest/AssertTruthy:
+  Enabled: true
+
+Minitest/AssertWithExpectedArgument:
+  Enabled: true
+
+Minitest/AssertionInLifecycleHook:
+  Enabled: true
+
+Minitest/DuplicateTestRun:
+  Enabled: true
+
+Minitest/EmptyLineBeforeAssertionMethods:
+  Enabled: true
+
+Minitest/GlobalExpectations:
+  Enabled: true
+
+Minitest/LifecycleHooksOrder:
+  Enabled: true
+
+Minitest/LiteralAsActualArgument:
+  Enabled: true
+
+Minitest/MultipleAssertions:
+  Enabled: true
+
+Minitest/NoAssertions:
+  Enabled: true
+
+Minitest/NoTestCases:
+  Enabled: true
+
+Minitest/NonPublicTestMethod:
+  Enabled: true
+
+Minitest/RefuteEmpty:
+  Enabled: true
+
+Minitest/RefuteEqual:
+  Enabled: true
+
+Minitest/RefuteFalse:
+  Enabled: true
+
+Minitest/RefuteInDelta:
+  Enabled: true
+
+Minitest/RefuteIncludes:
+  Enabled: true
+
+Minitest/RefuteInstanceOf:
+  Enabled: true
+
+Minitest/RefuteKindOf:
+  Enabled: true
+
+Minitest/RefuteMatch:
+  Enabled: true
+
+Minitest/RefuteNil:
+  Enabled: true
+
+Minitest/RefuteOperator:
+  Enabled: true
+
+Minitest/RefutePathExists:
+  Enabled: true
+
+Minitest/RefutePredicate:
+  Enabled: true
+
+Minitest/RefuteRespondTo:
+  Enabled: true
+
+Minitest/RefuteSame:
+  Enabled: true
+
+Minitest/ReturnInTestMethod:
+  Enabled: true
+
+Minitest/SkipEnsure:
+  Enabled: true
+
+Minitest/SkipWithoutReason:
+  Enabled: true
+
+Minitest/TestFileName:
+  Enabled: true
+
+Minitest/TestMethodName:
+  Enabled: true
+
+Minitest/UnreachableAssertion:
+  Enabled: true
+
+Minitest/UnspecifiedException:
+  Enabled: true
+
+Minitest/UselessAssertion:
   Enabled: true
 
 Performance:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -129,7 +129,7 @@ Minitest/LiteralAsActualArgument:
   Enabled: true
 
 Minitest/MultipleAssertions:
-  Enabled: true
+  Enabled: false
 
 Minitest/NoAssertions:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,6 @@ end
 
 group :rubocop do
   gem 'rubocop'
+  gem 'rubocop-minitest'
   gem 'rubocop-performance'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,8 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
+    rubocop-minitest (0.33.0)
+      rubocop (>= 1.39, < 2.0)
     rubocop-performance (1.19.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -272,6 +274,7 @@ DEPENDENCIES
   rails (~> 7.1.0)
   rails-controller-testing
   rubocop
+  rubocop-minitest
   rubocop-performance
   simplecov
   simplecov-cobertura

--- a/test/aliases_test.rb
+++ b/test/aliases_test.rb
@@ -54,6 +54,7 @@ class AliasesTest < ActionController::TestCase
   def test_assignments_before_calling_alias
     Student.stubs(:new).returns(mock_student)
     get :new
+
     assert_response :success
     assert_equal 'magical', assigns(:something)
   end
@@ -61,6 +62,7 @@ class AliasesTest < ActionController::TestCase
   def test_controller_should_render_new
     Student.stubs(:new).returns(mock_student)
     get :new
+
     assert_response :success
     assert_equal 'New HTML', @response.body.strip
   end
@@ -68,6 +70,7 @@ class AliasesTest < ActionController::TestCase
   def test_expose_the_requested_user_on_edit
     Student.expects(:find).with('42').returns(mock_student)
     get :edit, params: { id: '42' }
+
     assert_equal mock_student, assigns(:student)
     assert_response :success
   end
@@ -75,6 +78,7 @@ class AliasesTest < ActionController::TestCase
   def test_controller_should_render_edit
     Student.stubs(:find).returns(mock_student)
     get :edit, params: { id: '42' }
+
     assert_response :success
     assert_equal 'Edit HTML', @response.body.strip
   end
@@ -83,6 +87,7 @@ class AliasesTest < ActionController::TestCase
     @request.accept = 'application/xml'
     Student.stubs(:find).returns(mock_student)
     get :edit, params: { id: '42' }
+
     assert_response :success
     assert_equal 'Render XML', @response.body
   end
@@ -91,6 +96,7 @@ class AliasesTest < ActionController::TestCase
     Student.stubs(:new).returns(mock_student(save: true))
     @controller.stubs(:resource_url).returns('http://test.host/')
     post :create
+
     assert_response :success
     assert_equal "I won't redirect!", @response.body
   end
@@ -100,6 +106,7 @@ class AliasesTest < ActionController::TestCase
     Student.stubs(:new).returns(mock_student(save: false, errors: {some: :error}))
     @controller.stubs(:resource_url).returns('http://test.host/')
     post :create
+
     assert_response :success
     assert_equal "New HTML", @response.body.strip
   end
@@ -109,6 +116,7 @@ class AliasesTest < ActionController::TestCase
     Student.stubs(:new).returns(mock_student(save: false, errors: {some: :error}))
     @controller.stubs(:resource_url).returns('http://test.host/')
     post :create
+
     assert_response :success
     assert_equal "New HTML", @response.body.strip
   end
@@ -116,6 +124,7 @@ class AliasesTest < ActionController::TestCase
   def test_wont_render_edit_template_on_update_with_failure_if_failure_block_is_given
     Student.stubs(:find).returns(mock_student(update: false, errors: { fail: true }))
     put :update, params: { id: '42' }
+
     assert_response :success
     assert_equal "I won't render!", @response.body
   end
@@ -124,12 +133,14 @@ class AliasesTest < ActionController::TestCase
     Student.stubs(:find).returns(mock_student(update: true))
     @controller.stubs(:resource_url).returns('http://test.host/')
     put :update, params: { id: '42', student: {these: 'params'} }
+
     assert_equal mock_student, assigns(:student)
   end
 
   def test_block_is_called_when_student_is_destroyed
     Student.stubs(:find).returns(mock_student(destroy: true))
     delete :destroy, params: { id: '42' }
+
     assert_response :success
     assert_equal "Destroyed!", @response.body
   end
@@ -140,6 +151,7 @@ class AliasesTest < ActionController::TestCase
     Student.stubs(:new).returns(mock_student)
 
     post :create
+
     assert_equal "http://test.host/", @response.location
   end
 

--- a/test/association_chain_test.rb
+++ b/test/association_chain_test.rb
@@ -46,6 +46,7 @@ class BeginOfAssociationChainTest < ActionController::TestCase
     @controller.current_user.expects(:pets).returns(Pet)
     Pet.expects(:all).returns(mock_pet)
     get :index
+
     assert_response :success
     assert_equal 'Index HTML', @response.body.strip
   end
@@ -54,6 +55,7 @@ class BeginOfAssociationChainTest < ActionController::TestCase
     @controller.current_user.expects(:pets).returns(Pet)
     Pet.expects(:build).returns(mock_pet)
     get :new
+
     assert_response :success
     assert_equal 'New HTML', @response.body.strip
   end
@@ -62,6 +64,7 @@ class BeginOfAssociationChainTest < ActionController::TestCase
     @controller.current_user.expects(:pets).returns(Pet)
     Pet.expects(:find).with('47').returns(mock_pet)
     get :show, params: { id: '47' }
+
     assert_response :success
     assert_equal 'Show HTML', @response.body.strip
   end
@@ -70,6 +73,7 @@ class BeginOfAssociationChainTest < ActionController::TestCase
     @controller.current_user.expects(:pets).never
     Pet.expects(:find).never
     get :edit, params: { id: '47' }
+
     assert_response :success
     assert_equal 'new pet', assigns(:pet)
   end
@@ -78,6 +82,7 @@ class BeginOfAssociationChainTest < ActionController::TestCase
     @controller.current_user.expects(:pets).returns(Pet)
     Pet.expects(:build).with({}).returns(mock_pet)
     get :new
+
     assert_equal mock_pet, assigns(:pet)
   end
 
@@ -85,6 +90,7 @@ class BeginOfAssociationChainTest < ActionController::TestCase
     @controller.current_user.expects(:pets).returns(Pet)
     Pet.expects(:build).with({}).returns(mock_pet)
     get :new
+
     assert_equal [@controller.current_user], @controller.send(:association_chain)
   end
 
@@ -120,6 +126,7 @@ class AssociationChainTest < ActionController::TestCase
     Puppet.expects(:find).with('42').returns(mock_puppet)
     mock_puppet.expects(:destroy)
     delete :destroy, params: { id: '42', pet_id: '37' }
+
     assert_equal [mock_pet], @controller.send(:association_chain)
   end
 
@@ -127,7 +134,8 @@ class AssociationChainTest < ActionController::TestCase
     Puppet.expects(:find).with('42').returns(mock_puppet)
     mock_puppet.expects(:destroy)
     delete :destroy, params: { id: '42' }
-    assert_equal [], @controller.send(:association_chain)
+
+    assert_empty @controller.send(:association_chain)
   end
 
   protected

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -77,18 +77,21 @@ class IndexActionBaseTest < ActionController::TestCase
   def test_expose_all_users_as_instance_variable
     User.expects(:scoped).returns([mock_user])
     get :index
+
     assert_equal [mock_user], assigns(:users)
   end
 
   def test_apply_scopes_if_method_is_available
     User.expects(:scoped).returns([mock_user])
     get :index
+
     assert @controller.scopes_applied
   end
 
   def test_controller_should_render_index
     User.stubs(:scoped).returns([mock_user])
     get :index
+
     assert_response :success
     assert_equal 'Index HTML', @response.body.strip
   end
@@ -98,6 +101,7 @@ class IndexActionBaseTest < ActionController::TestCase
     User.expects(:scoped).returns(collection = [mock_user])
     collection.expects(:to_xml).returns('Generated XML')
     get :index
+
     assert_response :success
     assert_equal 'Generated XML', @response.body
   end
@@ -105,7 +109,8 @@ class IndexActionBaseTest < ActionController::TestCase
   def test_scoped_is_called_only_when_available
     User.stubs(:all).returns([mock_user])
     get :index
-    assert_equal Array, assigns(:users).class
+
+    assert_instance_of Array, assigns(:users)
   end
 end
 
@@ -115,12 +120,14 @@ class ShowActionBaseTest < ActionController::TestCase
   def test_expose_the_requested_user
     User.expects(:find).with('42').returns(mock_user)
     get :show, params: { id: '42' }
+
     assert_equal mock_user, assigns(:user)
   end
 
   def test_controller_should_render_show
     User.stubs(:find).returns(mock_user)
     get :show, params: { id: '42' }
+
     assert_response :success
     assert_equal 'Show HTML', @response.body.strip
   end
@@ -131,6 +138,7 @@ class ShowActionBaseTest < ActionController::TestCase
     mock_user.expects(:to_xml).returns("Generated XML")
 
     get :show, params: { id: '42' }
+
     assert_response :success
     assert_equal 'Generated XML', @response.body
   end
@@ -142,12 +150,14 @@ class NewActionBaseTest < ActionController::TestCase
   def test_expose_a_new_user
     User.expects(:new).returns(mock_user)
     get :new
+
     assert_equal mock_user, assigns(:user)
   end
 
   def test_controller_should_render_new
     User.stubs(:new).returns(mock_user)
     get :new
+
     assert_response :success
     assert_equal 'New HTML', @response.body.strip
   end
@@ -158,6 +168,7 @@ class NewActionBaseTest < ActionController::TestCase
     mock_user.expects(:to_xml).returns("Generated XML")
 
     get :new
+
     assert_response :success
     assert_equal 'Generated XML', @response.body
   end
@@ -169,6 +180,7 @@ class EditActionBaseTest < ActionController::TestCase
   def test_expose_the_requested_user
     User.expects(:find).with('42').returns(mock_user)
     get :edit, params: { id: '42' }
+
     assert_response :success
     assert_equal mock_user, assigns(:user)
   end
@@ -176,6 +188,7 @@ class EditActionBaseTest < ActionController::TestCase
   def test_controller_should_render_edit
     User.stubs(:find).returns(mock_user)
     get :edit, params: { id: '42' }
+
     assert_response :success
     assert_equal 'Edit HTML', @response.body.strip
   end
@@ -187,6 +200,7 @@ class CreateActionBaseTest < ActionController::TestCase
   def test_expose_a_newly_create_user_when_saved_with_success
     User.expects(:new).with(build_parameters({'these' => 'params'})).returns(mock_user(save: true))
     post :create, params: { user: {these: 'params'} }
+
     assert_equal mock_user, assigns(:user)
   end
 
@@ -194,6 +208,7 @@ class CreateActionBaseTest < ActionController::TestCase
     @controller.class.send(:with_role, :admin)
     User.expects(:new).with(build_parameters({'these' => 'params'}), {as: :admin}).returns(mock_user(save: true))
     post :create, params: { user: {these: 'params'} }
+
     assert_equal mock_user, assigns(:user)
   end
 
@@ -201,6 +216,7 @@ class CreateActionBaseTest < ActionController::TestCase
     @controller.class.send(:without_protection, true)
     User.expects(:new).with(build_parameters({'these' => 'params'}), {without_protection: true}).returns(mock_user(save: true))
     post :create, params: { user: {these: 'params'} }
+
     assert_equal mock_user, assigns(:user)
   end
 
@@ -208,24 +224,28 @@ class CreateActionBaseTest < ActionController::TestCase
     User.stubs(:new).returns(mock_user(save: true))
     @controller.expects(:resource_url).returns('http://test.host/')
     post :create, format: :html
+
     assert_redirected_to 'http://test.host/'
   end
 
   def test_show_flash_message_when_success
     User.stubs(:new).returns(mock_user(save: true))
     post :create
-    assert_equal flash[:notice], 'User was successfully created.'
+
+    assert_equal 'User was successfully created.', flash[:notice]
   end
 
   def test_show_flash_message_with_javascript_request_when_success
     User.stubs(:new).returns(mock_user(save: true))
     post :create, format: :js
-    assert_equal flash[:notice], 'User was successfully created.'
+
+    assert_equal 'User was successfully created.', flash[:notice]
   end
 
   def test_render_new_template_when_user_cannot_be_saved
     User.stubs(:new).returns(mock_user(save: false, errors: {some: :error}))
     post :create
+
     assert_response :success
     assert_equal "New HTML", @response.body.strip
   end
@@ -233,7 +253,8 @@ class CreateActionBaseTest < ActionController::TestCase
   def test_dont_show_flash_message_when_user_cannot_be_saved
     User.stubs(:new).returns(mock_user(save: false, errors: {some: :error}))
     post :create
-    assert flash.empty?
+
+    assert_empty flash
   end
 end
 
@@ -244,6 +265,7 @@ class UpdateActionBaseTest < ActionController::TestCase
     User.expects(:find).with('42').returns(mock_user)
     mock_user.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: '42', user: {these: 'params'} }
+
     assert_equal mock_user, assigns(:user)
   end
 
@@ -252,6 +274,7 @@ class UpdateActionBaseTest < ActionController::TestCase
     User.expects(:find).with('42').returns(mock_user)
     mock_user.expects(:update).with(build_parameters({'these' => 'params'}), {as: :admin}).returns(true)
     put :update, params: { id: '42', user: {these: 'params'} }
+
     assert_equal mock_user, assigns(:user)
   end
 
@@ -260,6 +283,7 @@ class UpdateActionBaseTest < ActionController::TestCase
     User.expects(:find).with('42').returns(mock_user)
     mock_user.expects(:update).with(build_parameters({'these' => 'params'}), {without_protection: true}).returns(true)
     put :update, params: { id: '42', user: {these: 'params'} }
+
     assert_equal mock_user, assigns(:user)
   end
 
@@ -267,6 +291,7 @@ class UpdateActionBaseTest < ActionController::TestCase
     User.stubs(:find).returns(mock_user(update: true))
     @controller.expects(:resource_url).returns('http://test.host/')
     put :update, params: { id: '42' }
+
     assert_redirected_to 'http://test.host/'
   end
 
@@ -275,24 +300,28 @@ class UpdateActionBaseTest < ActionController::TestCase
     User.stubs(:find).returns(mock_user(update: true))
     @controller.expects(:collection_url).returns('http://test.host/')
     put :update, params: { id: '42' }
+
     assert_redirected_to 'http://test.host/'
   end
 
   def test_show_flash_message_when_success
     User.stubs(:find).returns(mock_user(update: true))
     put :update, params: { id: '42' }
-    assert_equal flash[:notice], 'User was successfully updated.'
+
+    assert_equal 'User was successfully updated.', flash[:notice]
   end
 
   def test_show_flash_message_with_javascript_request_when_success
     User.stubs(:find).returns(mock_user(update: true))
     post :update, params: { id: '42' }, format: :js
-    assert_equal flash[:notice], 'User was successfully updated.'
+
+    assert_equal 'User was successfully updated.', flash[:notice]
   end
 
   def test_render_edit_template_when_user_cannot_be_saved
     User.stubs(:find).returns(mock_user(update: false, errors: {some: :error}))
     put :update, params: { id: '42' }
+
     assert_response :success
     assert_equal "Edit HTML", @response.body.strip
   end
@@ -300,7 +329,8 @@ class UpdateActionBaseTest < ActionController::TestCase
   def test_dont_show_flash_message_when_user_cannot_be_saved
     User.stubs(:find).returns(mock_user(update: false, errors: {some: :error}))
     put :update, params: { id: '42' }
-    assert flash.empty?
+
+    assert_empty flash
   end
 end
 
@@ -311,37 +341,43 @@ class DestroyActionBaseTest < ActionController::TestCase
     User.expects(:find).with('42').returns(mock_user)
     mock_user.expects(:destroy).returns(true)
     delete :destroy, params: { id: '42' }
+
     assert_equal mock_user, assigns(:user)
   end
 
   def test_show_flash_message_when_user_can_be_deleted
     User.stubs(:find).returns(mock_user(destroy: true))
     delete :destroy, params: { id: '42' }
-    assert_equal flash[:notice], 'User was successfully destroyed.'
+
+    assert_equal 'User was successfully destroyed.', flash[:notice]
   end
 
   def test_show_flash_message_with_javascript_request_when_user_can_be_deleted
     User.stubs(:find).returns(mock_user(destroy: true))
     delete :destroy, params: { id: '42' }, format: :js
-    assert_equal flash[:notice], 'User was successfully destroyed.'
+
+    assert_equal 'User was successfully destroyed.', flash[:notice]
   end
 
   def test_show_flash_message_when_user_cannot_be_deleted
     User.stubs(:find).returns(mock_user(destroy: false, errors: { fail: true }))
     delete :destroy, params: { id: '42' }
-    assert_equal flash[:alert], 'User could not be destroyed.'
+
+    assert_equal 'User could not be destroyed.', flash[:alert]
   end
 
   def test_show_flash_message_with_javascript_request_when_user_cannot_be_deleted
     User.stubs(:find).returns(mock_user(destroy: false, errors: { fail: true }))
     delete :destroy, params: { id: '42' }, format: :js
-    assert_equal flash[:alert], 'User could not be destroyed.'
+
+    assert_equal 'User could not be destroyed.', flash[:alert]
   end
 
   def test_redirects_to_users_list
     User.stubs(:find).returns(mock_user(destroy: true))
     @controller.expects(:collection_url).returns('http://test.host/')
     delete :destroy, params: { id: '42' }
+
     assert_redirected_to 'http://test.host/'
   end
 
@@ -349,6 +385,7 @@ class DestroyActionBaseTest < ActionController::TestCase
     User.stubs(:find).returns(mock_user(destroy: false))
     @controller.expects(:collection_url).returns('http://test.host/')
     delete :destroy, params: { id: '42' }
+
     assert_redirected_to 'http://test.host/'
   end
 end

--- a/test/belongs_to_test.rb
+++ b/test/belongs_to_test.rb
@@ -31,6 +31,7 @@ class BelongsToTest < ActionController::TestCase
   def test_expose_all_comments_as_instance_variable_on_index
     Comment.expects(:scoped).returns([mock_comment])
     get :index, params: { post_id: '37' }
+
     assert_equal mock_post, assigns(:post)
     assert_equal [mock_comment], assigns(:comments)
   end
@@ -38,6 +39,7 @@ class BelongsToTest < ActionController::TestCase
   def test_expose_the_requested_comment_on_show
     Comment.expects(:find).with('42').returns(mock_comment)
     get :show, params: { id: '42', post_id: '37' }
+
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
   end
@@ -45,6 +47,7 @@ class BelongsToTest < ActionController::TestCase
   def test_expose_a_new_comment_on_new
     Comment.expects(:build).returns(mock_comment)
     get :new, params: { post_id: '37' }
+
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
   end
@@ -52,6 +55,7 @@ class BelongsToTest < ActionController::TestCase
   def test_expose_the_requested_comment_on_edit
     Comment.expects(:find).with('42').returns(mock_comment)
     get :edit, params: { id: '42', post_id: '37' }
+
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
   end
@@ -59,6 +63,7 @@ class BelongsToTest < ActionController::TestCase
   def test_expose_a_newly_create_comment_on_create
     Comment.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_comment(save: true))
     post :create, params: { post_id: '37', comment: {these: 'params'} }
+
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
   end
@@ -67,6 +72,7 @@ class BelongsToTest < ActionController::TestCase
     Comment.expects(:find).with('42').returns(mock_comment)
     mock_comment.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: '42', post_id: '37', comment: {these: 'params'} }
+
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
   end
@@ -75,6 +81,7 @@ class BelongsToTest < ActionController::TestCase
     Comment.expects(:find).with('42').returns(mock_comment)
     mock_comment.expects(:destroy)
     delete :destroy, params: { id: '42', post_id: '37' }
+
     assert_equal mock_post, assigns(:post)
     assert_equal mock_comment, assigns(:comment)
   end
@@ -87,10 +94,10 @@ class BelongsToTest < ActionController::TestCase
     Comment.expects(:scoped).returns([mock_comment])
     get :index, params: { post_id: '37' }
 
-    assert helper_methods.include?('parent?')
+    assert_includes helper_methods, 'parent?'
     assert @controller.send(:parent?)
     assert_equal mock_post, assigns(:post)
-    assert helper_methods.include?('parent')
+    assert_includes helper_methods, 'parent'
     assert_equal mock_post, @controller.send(:parent)
   end
 
@@ -138,6 +145,7 @@ class BelongsToWithRedirectsTest < ActionController::TestCase
     @controller.expects(:parent_url).returns('http://test.host/')
     Reply.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_reply(save: true))
     post :create, params: { post_id: '37', reply: { these: 'params' } }
+
     assert_redirected_to 'http://test.host/'
   end
 
@@ -145,6 +153,7 @@ class BelongsToWithRedirectsTest < ActionController::TestCase
     Reply.stubs(:find).returns(mock_reply(update: true))
     @controller.expects(:parent_url).returns('http://test.host/')
     put :update, params: { id: '42', post_id: '37', reply: { these: 'params' } }
+
     assert_redirected_to 'http://test.host/'
   end
 
@@ -153,6 +162,7 @@ class BelongsToWithRedirectsTest < ActionController::TestCase
     mock_reply.expects(:destroy)
     @controller.expects(:parent_url).returns('http://test.host/')
     delete :destroy, params: { id: '42', post_id: '37' }
+
     assert_redirected_to 'http://test.host/'
   end
 

--- a/test/belongs_to_with_shallow_test.rb
+++ b/test/belongs_to_with_shallow_test.rb
@@ -33,6 +33,7 @@ class BelongsToWithShallowTest < ActionController::TestCase
   def test_expose_all_tags_as_instance_variable_on_index
     Tag.expects(:scoped).returns([mock_tag])
     get :index, params: { post_id: 'thirty_seven' }
+
     assert_equal mock_post, assigns(:post)
     assert_equal [mock_tag], assigns(:tags)
   end
@@ -40,6 +41,7 @@ class BelongsToWithShallowTest < ActionController::TestCase
   def test_expose_a_new_tag_on_new
     Tag.expects(:build).returns(mock_tag)
     get :new, params: { post_id: 'thirty_seven' }
+
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)
   end
@@ -47,6 +49,7 @@ class BelongsToWithShallowTest < ActionController::TestCase
   def test_expose_a_newly_create_tag_on_create
     Tag.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_tag(save: true))
     post :create, params: { post_id: 'thirty_seven', tag: {these: 'params'} }
+
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)
   end
@@ -54,6 +57,7 @@ class BelongsToWithShallowTest < ActionController::TestCase
   def test_expose_the_requested_tag_on_show
     should_find_parents
     get :show, params: { id: '42' }
+
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)
   end
@@ -61,6 +65,7 @@ class BelongsToWithShallowTest < ActionController::TestCase
   def test_expose_the_requested_tag_on_edit
     should_find_parents
     get :edit, params: { id: '42' }
+
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)
   end
@@ -69,6 +74,7 @@ class BelongsToWithShallowTest < ActionController::TestCase
     should_find_parents
     mock_tag.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: '42', tag: {these: 'params'} }
+
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)
   end
@@ -77,6 +83,7 @@ class BelongsToWithShallowTest < ActionController::TestCase
     should_find_parents
     mock_tag.expects(:destroy)
     delete :destroy, params: { id: '42', post_id: '37' }
+
     assert_equal mock_post, assigns(:post)
     assert_equal mock_tag, assigns(:tag)
   end

--- a/test/changelog_test.rb
+++ b/test/changelog_test.rb
@@ -8,6 +8,7 @@ class ChangelogTest < ActiveSupport::TestCase
 
   def test_has_definitions_for_all_implicit_links
     implicit_link_names = @changelog.scan(/\[([^\]]+)\]\[\]/).flatten.uniq
+
     implicit_link_names.each do |name|
       assert_includes @changelog, "[#{name}]: https"
     end

--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -144,7 +144,7 @@ class DefaultsClassMethodTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_are_recreated_when_defaults_change
+  def test_url_helpers_are_recreated_when_defaults_change # rubocop:disable Minitest/NoAssertions
     BooksController.expects(:create_resources_url_helpers!).returns(true).once
     BooksController.send(:defaults, instance_name: 'string', collection_name: 'strings')
   end
@@ -167,7 +167,7 @@ class BelongsToErrorsTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_are_recreated_just_once_when_belongs_to_is_called_with_block
+  def test_url_helpers_are_recreated_just_once_when_belongs_to_is_called_with_block # rubocop:disable Minitest/NoAssertions
     DeansController.expects(:create_resources_url_helpers!).returns(true).once
     DeansController.send(:belongs_to, :school) do
       belongs_to :association
@@ -176,7 +176,7 @@ class BelongsToErrorsTest < ActiveSupport::TestCase
     DeansController.send(:parents_symbols=, [:school])
   end
 
-  def test_url_helpers_are_recreated_just_once_when_belongs_to_is_called_with_multiple_blocks
+  def test_url_helpers_are_recreated_just_once_when_belongs_to_is_called_with_multiple_blocks # rubocop:disable Minitest/NoAssertions
     DeansController.expects(:create_resources_url_helpers!).returns(true).once
     DeansController.send(:belongs_to, :school) do
       belongs_to :association do
@@ -233,7 +233,7 @@ class MountableEngineTest < ActiveSupport::TestCase
 end
 
 class EngineLoadErrorTest < ActiveSupport::TestCase
-  def test_does_not_crash_on_engine_load_error
+  def test_does_not_crash_on_engine_load_error # rubocop:disable Minitest/NoAssertions
     ActiveSupport::Dependencies.autoload_paths << 'test/autoload'
 
     EmptyNamespace.class_eval <<-RUBY

--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -88,10 +88,11 @@ class ActionsClassMethodTest < ActionController::TestCase
 
   def test_actions_are_undefined
     action_methods = BooksController.send(:action_methods).map(&:to_sym)
+
     assert_equal 4, action_methods.size
 
     [:index, :show, :delete, :search].each do |action|
-      assert action_methods.include?(action)
+      assert_includes action_methods, action
     end
 
     instance_methods = BooksController.send(:instance_methods).map(&:to_sym)
@@ -103,10 +104,11 @@ class ActionsClassMethodTest < ActionController::TestCase
 
   def test_actions_are_undefined_when_except_option_is_given
     action_methods = ReadersController.send(:action_methods)
+
     assert_equal 5, action_methods.size
 
     ['index', 'new', 'show', 'create', 'destroy'].each do |action|
-      assert action_methods.include? action
+      assert_includes action_methods, action
     end
   end
 end
@@ -187,21 +189,25 @@ class BelongsToErrorsTest < ActiveSupport::TestCase
 
   def test_belongs_to_for_namespaced_controller_and_namespaced_model_fetches_model_in_the_namespace_firstly
     Library::SubcategoriesController.send(:belongs_to, :category)
+
     assert_equal Library::Category, Library::SubcategoriesController.resources_configuration[:category][:parent_class]
   end
 
   def test_belongs_to_for_namespaced_controller_and_non_namespaced_model_sets_parent_class_properly
     Library::SubcategoriesController.send(:belongs_to, :book)
+
     assert_equal Book, Library::SubcategoriesController.resources_configuration[:book][:parent_class]
   end
 
   def test_belongs_to_for_namespaced_model_sets_parent_class_properly
     Library::SubcategoriesController.send(:belongs_to, :library, class_name: 'Library::Base')
+
     assert_equal Library::Base, Library::SubcategoriesController.resources_configuration[:library][:parent_class]
   end
 
   def test_belongs_to_without_namespace_sets_parent_class_properly
     FoldersController.send(:belongs_to, :book)
+
     assert_equal Book, FoldersController.resources_configuration[:book][:parent_class]
   end
 end
@@ -217,6 +223,7 @@ end
 class MountableEngineTest < ActiveSupport::TestCase
   def test_route_prefix_do_not_include_engine_name
     puts MyEngine::PeopleController.send(:resources_configuration)[:self][:route_prefix]
+
     assert_nil MyEngine::PeopleController.send(:resources_configuration)[:self][:route_prefix]
   end
 

--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -98,7 +98,7 @@ class ActionsClassMethodTest < ActionController::TestCase
     instance_methods = BooksController.send(:instance_methods).map(&:to_sym)
 
     [:new, :edit, :create, :update, :destroy].each do |action|
-      assert !instance_methods.include?(action)
+      refute_includes instance_methods, action
     end
   end
 

--- a/test/customized_base_test.rb
+++ b/test/customized_base_test.rb
@@ -80,6 +80,7 @@ class IndexActionCustomizedBaseTest < ActionController::TestCase
   def test_expose_all_users_as_instance_variable
     Car.expects(:get_all).returns([mock_car])
     get :index
+
     assert_equal [mock_car], assigns(:cars)
   end
 end
@@ -90,6 +91,7 @@ class ShowActionCustomizedBaseTest < ActionController::TestCase
   def test_expose_the_requested_user
     Car.expects(:get).with('42').returns(mock_car)
     get :show, params: { id: '42' }
+
     assert_equal mock_car, assigns(:car)
   end
 end
@@ -100,6 +102,7 @@ class NewActionCustomizedBaseTest < ActionController::TestCase
   def test_expose_a_new_user
     Car.expects(:create_new).returns(mock_car)
     get :new
+
     assert_equal mock_car, assigns(:car)
   end
 end
@@ -110,6 +113,7 @@ class EditActionCustomizedBaseTest < ActionController::TestCase
   def test_expose_the_requested_user
     Car.expects(:get).with('42').returns(mock_car)
     get :edit, params: { id: '42' }
+
     assert_response :success
     assert_equal mock_car, assigns(:car)
   end
@@ -121,6 +125,7 @@ class CreateActionCustomizedBaseTest < ActionController::TestCase
   def test_expose_a_newly_create_user_when_saved_with_success
     Car.expects(:create_new).with(build_parameters({'these' => 'params'})).returns(mock_car(save_successfully: true))
     post :create, params: { car: {these: 'params'} }
+
     assert_equal mock_car, assigns(:car)
   end
 
@@ -128,12 +133,14 @@ class CreateActionCustomizedBaseTest < ActionController::TestCase
     Car.stubs(:create_new).returns(mock_car(save_successfully: true))
     @controller.expects(:resource_url).returns('http://test.host/')
     post :create
+
     assert_redirected_to 'http://test.host/'
   end
 
   def test_render_new_template_when_user_cannot_be_saved
     Car.stubs(:create_new).returns(mock_car(save_successfully: false, errors: {some: :error}))
     post :create
+
     assert_response :success
     assert_equal "New HTML", @response.body.strip
   end
@@ -146,6 +153,7 @@ class UpdateActionCustomizedBaseTest < ActionController::TestCase
     Car.expects(:get).with('42').returns(mock_car)
     mock_car.expects(:update_successfully).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: '42', car: {these: 'params'} }
+
     assert_equal mock_car, assigns(:car)
   end
 
@@ -153,12 +161,14 @@ class UpdateActionCustomizedBaseTest < ActionController::TestCase
     Car.stubs(:get).returns(mock_car(update_successfully: true))
     @controller.expects(:resource_url).returns('http://test.host/')
     put :update, params: { id: '42' }
+
     assert_redirected_to 'http://test.host/'
   end
 
   def test_render_edit_template_when_user_cannot_be_saved
     Car.stubs(:get).returns(mock_car(update_successfully: false, errors: {some: :error}))
     put :update, params: { id: '42' }
+
     assert_response :success
     assert_equal "Edit HTML", @response.body.strip
   end
@@ -171,18 +181,21 @@ class DestroyActionCustomizedBaseTest < ActionController::TestCase
     Car.expects(:get).with('42').returns(mock_car)
     mock_car.expects(:destroy_successfully)
     delete :destroy, params: { id: '42' }
+
     assert_equal mock_car, assigns(:car)
   end
 
   def test_show_flash_message_when_user_can_be_deleted
     Car.stubs(:get).returns(mock_car(destroy_successfully: true))
     delete :destroy, params: { id: '42' }
-    assert_equal flash[:notice], 'Car was successfully destroyed.'
+
+    assert_equal 'Car was successfully destroyed.', flash[:notice]
   end
 
   def test_show_flash_message_when_cannot_be_deleted
     Car.stubs(:get).returns(mock_car(destroy_successfully: false, errors: { fail: true }))
     delete :destroy, params: { id: '42' }
-    assert_equal flash[:alert], 'Car could not be destroyed.'
+
+    assert_equal 'Car could not be destroyed.', flash[:alert]
   end
 end

--- a/test/customized_belongs_to_test.rb
+++ b/test/customized_belongs_to_test.rb
@@ -31,42 +31,49 @@ class CustomizedBelongsToTest < ActionController::TestCase
   def test_expose_the_requested_school_with_chosen_instance_variable_on_index
     Professor.stubs(:scoped).returns([mock_professor])
     get :index, params: { school_title: 'nice' }
+
     assert_equal mock_school, assigns(:great_school)
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_show
     Professor.stubs(:find).returns(mock_professor)
     get :show, params: { id: 42, school_title: 'nice' }
+
     assert_equal mock_school, assigns(:great_school)
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_new
     Professor.stubs(:build).returns(mock_professor)
     get :new, params: { school_title: 'nice' }
+
     assert_equal mock_school, assigns(:great_school)
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_edit
     Professor.stubs(:find).returns(mock_professor)
     get :edit, params: { id: 42, school_title: 'nice' }
+
     assert_equal mock_school, assigns(:great_school)
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_create
     Professor.stubs(:build).returns(mock_professor(save: true))
     post :create, params: { school_title: 'nice' }
+
     assert_equal mock_school, assigns(:great_school)
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_update
     Professor.stubs(:find).returns(mock_professor(update: true))
     put :update, params: { id: 42, school_title: 'nice' }
+
     assert_equal mock_school, assigns(:great_school)
   end
 
   def test_expose_the_requested_school_with_chosen_instance_variable_on_destroy
     Professor.stubs(:find).returns(mock_professor(destroy: true))
     delete :destroy, params: { id: 42, school_title: 'nice' }
+
     assert_equal mock_school, assigns(:great_school)
   end
 

--- a/test/customized_redirect_to_test.rb
+++ b/test/customized_redirect_to_test.rb
@@ -23,15 +23,19 @@ class RedirectToIndexWithoutShowTest < ActionController::TestCase
 
   def test_redirect_index_url_after_create
     Post.stubs(:new).returns(mock_machine(save: true))
+
     assert !PostsController.respond_to?(:show)
     post :create
+
     assert_redirected_to 'http://test.host/posts'
   end
 
   def test_redirect_to_index_url_after_update
     Post.stubs(:find).returns(mock_machine(update: true))
+
     assert !PostsController.respond_to?(:show)
     put :update, params: { id: '42' }
+
     assert_redirected_to 'http://test.host/posts'
   end
 

--- a/test/customized_redirect_to_test.rb
+++ b/test/customized_redirect_to_test.rb
@@ -24,7 +24,7 @@ class RedirectToIndexWithoutShowTest < ActionController::TestCase
   def test_redirect_index_url_after_create
     Post.stubs(:new).returns(mock_machine(save: true))
 
-    assert !PostsController.respond_to?(:show)
+    refute_respond_to PostsController, :show
     post :create
 
     assert_redirected_to 'http://test.host/posts'
@@ -33,7 +33,7 @@ class RedirectToIndexWithoutShowTest < ActionController::TestCase
   def test_redirect_to_index_url_after_update
     Post.stubs(:find).returns(mock_machine(update: true))
 
-    assert !PostsController.respond_to?(:show)
+    refute_respond_to PostsController, :show
     put :update, params: { id: '42' }
 
     assert_redirected_to 'http://test.host/posts'

--- a/test/defaults_test.rb
+++ b/test/defaults_test.rb
@@ -30,24 +30,28 @@ class DefaultsTest < ActionController::TestCase
   def test_expose_all_painters_as_instance_variable
     Malarz.expects(:scoped).returns([mock_painter])
     get :index
+
     assert_equal [mock_painter], assigns(:malarze)
   end
 
   def test_expose_the_requested_painter_on_show
     Malarz.expects(:find_by_slug).with('forty_two').returns(mock_painter)
     get :show, params: { id: 'forty_two' }
+
     assert_equal mock_painter, assigns(:malarz)
   end
 
   def test_expose_a_new_painter
     Malarz.expects(:new).returns(mock_painter)
     get :new
+
     assert_equal mock_painter, assigns(:malarz)
   end
 
   def test_expose_the_requested_painter_on_edit
     Malarz.expects(:find_by_slug).with('forty_two').returns(mock_painter)
     get :edit, params: { id: 'forty_two' }
+
     assert_response :success
     assert_equal mock_painter, assigns(:malarz)
   end
@@ -55,6 +59,7 @@ class DefaultsTest < ActionController::TestCase
   def test_expose_a_newly_create_painter_when_saved_with_success
     Malarz.expects(:new).with(build_parameters({'these' => 'params'})).returns(mock_painter(save: true))
     post :create, params: { malarz: {these: 'params'} }
+
     assert_equal mock_painter, assigns(:malarz)
   end
 
@@ -62,6 +67,7 @@ class DefaultsTest < ActionController::TestCase
     Malarz.expects(:find_by_slug).with('forty_two').returns(mock_painter)
     mock_painter.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: 'forty_two', malarz: {these: 'params'} }
+
     assert_equal mock_painter, assigns(:malarz)
   end
 
@@ -69,6 +75,7 @@ class DefaultsTest < ActionController::TestCase
     Malarz.expects(:find_by_slug).with('forty_two').returns(mock_painter)
     mock_painter.expects(:destroy)
     delete :destroy, params: { id: 'forty_two' }
+
     assert_equal mock_painter, assigns(:malarz)
   end
 
@@ -109,24 +116,28 @@ class DefaultsNamespaceTest < ActionController::TestCase
   def test_expose_all_lecturers_as_instance_variable
     Lecturer.expects(:scoped).returns([mock_lecturer])
     get :index
+
     assert_equal [mock_lecturer], assigns(:lecturers)
   end
 
   def test_expose_the_requested_lecturer_on_show
     Lecturer.expects(:find_by_slug).with('forty_two').returns(mock_lecturer)
     get :show, params: { id: 'forty_two' }
+
     assert_equal mock_lecturer, assigns(:lecturer)
   end
 
   def test_expose_a_new_lecturer
     Lecturer.expects(:new).returns(mock_lecturer)
     get :new
+
     assert_equal mock_lecturer, assigns(:lecturer)
   end
 
   def test_expose_the_requested_lecturer_on_edit
     Lecturer.expects(:find_by_slug).with('forty_two').returns(mock_lecturer)
     get :edit, params: { id: 'forty_two' }
+
     assert_response :success
     assert_equal mock_lecturer, assigns(:lecturer)
   end
@@ -134,6 +145,7 @@ class DefaultsNamespaceTest < ActionController::TestCase
   def test_expose_a_newly_create_lecturer_when_saved_with_success
     Lecturer.expects(:new).with(build_parameters({'these' => 'params'})).returns(mock_lecturer(save: true))
     post :create, params: { lecturer: {these: 'params'} }
+
     assert_equal mock_lecturer, assigns(:lecturer)
   end
 
@@ -141,6 +153,7 @@ class DefaultsNamespaceTest < ActionController::TestCase
     Lecturer.expects(:find_by_slug).with('forty_two').returns(mock_lecturer)
     mock_lecturer.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: 'forty_two', lecturer: {these: 'params'} }
+
     assert_equal mock_lecturer, assigns(:lecturer)
   end
 
@@ -148,6 +161,7 @@ class DefaultsNamespaceTest < ActionController::TestCase
     Lecturer.expects(:find_by_slug).with('forty_two').returns(mock_lecturer)
     mock_lecturer.expects(:destroy)
     delete :destroy, params: { id: 'forty_two' }
+
     assert_equal mock_lecturer, assigns(:lecturer)
   end
 
@@ -177,6 +191,7 @@ class NamespacedModelForNamespacedController < ActionController::TestCase
   def test_that_it_picked_the_namespaced_model
     # make public so we can test it
     Admin::GroupsController.send(:public, :resource_class)
+
     assert_equal Admin::Group, @controller.resource_class
   end
 end
@@ -193,6 +208,7 @@ class TwoPartNameModelForNamespacedController < ActionController::TestCase
   def test_that_it_picked_the_camelcased_model
     # make public so we can test it
     Admin::RolesController.send(:public, :resource_class)
+
     assert_equal AdminRole, @controller.resource_class
   end
 end
@@ -207,12 +223,14 @@ class AnotherTwoPartNameModelForNamespacedController < ActionController::TestCas
   def test_that_it_picked_the_camelcased_model
     # make public so we can test it
     Admin::UsersController.send(:public, :resource_class)
+
     assert_equal User, @controller.resource_class
   end
 
   def test_that_it_got_the_request_params_right
     # make public so we can test it
     Admin::UsersController.send(:public, :resources_configuration)
+
     assert_equal 'user', @controller.resources_configuration[:self][:request_name]
   end
 end

--- a/test/multiple_nested_optional_belongs_to_test.rb
+++ b/test/multiple_nested_optional_belongs_to_test.rb
@@ -34,6 +34,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_student.expects(:projects).returns(Project)
     Project.expects(:scoped).returns([mock_project])
     get :index, params: { student_id: '37' }
+
     assert_equal mock_student, assigns(:student)
     assert_equal [mock_project], assigns(:projects)
   end
@@ -43,6 +44,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_manager.expects(:projects).returns(Project)
     Project.expects(:scoped).returns([mock_project])
     get :index, params: { manager_id: '38' }
+
     assert_equal mock_manager, assigns(:manager)
     assert_equal [mock_project], assigns(:projects)
   end
@@ -52,6 +54,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_employee.expects(:projects).returns(Project)
     Project.expects(:scoped).returns([mock_project])
     get :index, params: { employee_id: '666' }
+
     assert_equal mock_employee, assigns(:employee)
     assert_equal [mock_project], assigns(:projects)
   end
@@ -63,6 +66,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_employee.expects(:projects).returns(Project)
     Project.expects(:scoped).returns([mock_project])
     get :index, params: { manager_id: '37', employee_id: '42' }
+
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_employee, assigns(:employee)
     assert_equal [mock_project], assigns(:projects)
@@ -71,6 +75,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
   def test_expose_all_projects_as_instance_variable_without_parents
     Project.expects(:scoped).returns([mock_project])
     get :index
+
     assert_equal [mock_project], assigns(:projects)
   end
 
@@ -80,6 +85,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_student.expects(:projects).returns(Project)
     Project.expects(:find).with('42').returns(mock_project)
     get :show, params: { id: '42', student_id: '37' }
+
     assert_equal mock_student, assigns(:student)
     assert_equal mock_project, assigns(:project)
   end
@@ -89,6 +95,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_manager.expects(:projects).returns(Project)
     Project.expects(:find).with('42').returns(mock_project)
     get :show, params: { id: '42', manager_id: '37' }
+
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_project, assigns(:project)
   end
@@ -98,6 +105,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_employee.expects(:projects).returns(Project)
     Project.expects(:find).with('42').returns(mock_project)
     get :show, params: { id: '42', employee_id: '37' }
+
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
   end
@@ -109,6 +117,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_employee.expects(:projects).returns(Project)
     Project.expects(:find).with('13').returns(mock_project)
     get :show, params: { id: '13', manager_id: '37', employee_id: '42' }
+
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
@@ -117,6 +126,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
   def test_expose_the_requested_project_without_parents
     Project.expects(:find).with('13').returns(mock_project)
     get :show, params: { id: '13' }
+
     assert_equal mock_project, assigns(:project)
   end
 
@@ -126,6 +136,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_student.expects(:projects).returns(Project)
     Project.expects(:build).returns(mock_project)
     get :new, params: { student_id: '37' }
+
     assert_equal mock_student, assigns(:student)
     assert_equal mock_project, assigns(:project)
   end
@@ -135,6 +146,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_manager.expects(:projects).returns(Project)
     Project.expects(:build).returns(mock_project)
     get :new, params: { manager_id: '37' }
+
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_project, assigns(:project)
   end
@@ -144,6 +156,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_employee.expects(:projects).returns(Project)
     Project.expects(:build).returns(mock_project)
     get :new, params: { employee_id: '37' }
+
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
   end
@@ -155,6 +168,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_employee.expects(:projects).returns(Project)
     Project.expects(:build).returns(mock_project)
     get :new, params: { manager_id: '37', employee_id: '42' }
+
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
@@ -163,6 +177,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
   def test_expose_a_new_project_without_parents
     Project.expects(:new).returns(mock_project)
     get :new
+
     assert_equal mock_project, assigns(:project)
   end
 
@@ -172,6 +187,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_student.expects(:projects).returns(Project)
     Project.expects(:find).with('42').returns(mock_project)
     get :edit, params: { id: '42', student_id: '37' }
+
     assert_equal mock_student, assigns(:student)
     assert_equal mock_project, assigns(:project)
   end
@@ -181,6 +197,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_manager.expects(:projects).returns(Project)
     Project.expects(:find).with('42').returns(mock_project)
     get :edit, params: { id: '42', manager_id: '37' }
+
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_project, assigns(:project)
   end
@@ -190,6 +207,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_employee.expects(:projects).returns(Project)
     Project.expects(:find).with('42').returns(mock_project)
     get :edit, params: { id: '42', employee_id: '37' }
+
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
   end
@@ -201,6 +219,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_employee.expects(:projects).returns(Project)
     Project.expects(:find).with('13').returns(mock_project)
     get :edit, params: { id: '13', manager_id: '37', employee_id: '42' }
+
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
@@ -209,6 +228,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
   def test_expose_the_requested_project_for_edition_without_parents
     Project.expects(:find).with('13').returns(mock_project)
     get :edit, params: { id: '13' }
+
     assert_equal mock_project, assigns(:project)
   end
 
@@ -218,6 +238,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_student.expects(:projects).returns(Project)
     Project.expects(:build).with(build_parameters({ 'these' => 'params' })).returns(mock_project(save: true))
     post :create, params: { student_id: '37', project: { these: 'params' } }
+
     assert_equal mock_student, assigns(:student)
     assert_equal mock_project, assigns(:project)
   end
@@ -227,6 +248,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_manager.expects(:projects).returns(Project)
     Project.expects(:build).with(build_parameters({ 'these' => 'params' })).returns(mock_project(save: true))
     post :create, params: { manager_id: '37', project: { these: 'params' } }
+
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_project, assigns(:project)
   end
@@ -236,6 +258,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_employee.expects(:projects).returns(Project)
     Project.expects(:build).with(build_parameters({ 'these' => 'params' })).returns(mock_project(save: true))
     post :create, params: { employee_id: '37', project: { these: 'params' } }
+
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
   end
@@ -247,6 +270,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_employee.expects(:projects).returns(Project)
     Project.expects(:build).with(build_parameters({ 'these' => 'params' })).returns(mock_project(save: true))
     post :create, params: { manager_id: '37', employee_id: '42', project: { these: 'params' } }
+
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
@@ -255,6 +279,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
   def test_expose_a_newly_created_project_without_parents
     Project.expects(:new).with(build_parameters({ 'these' => 'params' })).returns(mock_project(save: true))
     post :create, params: { project: { these: 'params' } }
+
     assert_equal mock_project, assigns(:project)
   end
 
@@ -265,6 +290,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     Project.expects(:find).with('42').returns(mock_project)
     mock_project.expects(:update).with(build_parameters({ 'these' => 'params' })).returns(true)
     put :update, params: { id: '42', student_id: '37', project: { these: 'params' } }
+
     assert_equal mock_student, assigns(:student)
     assert_equal mock_project, assigns(:project)
   end
@@ -275,6 +301,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     Project.expects(:find).with('42').returns(mock_project)
     mock_project.expects(:update).with(build_parameters({ 'these' => 'params' })).returns(true)
     put :update, params: { id: '42', manager_id: '37', project: { these: 'params' } }
+
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_project, assigns(:project)
   end
@@ -285,6 +312,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     Project.expects(:find).with('42').returns(mock_project)
     mock_project.expects(:update).with(build_parameters({ 'these' => 'params' })).returns(true)
     put :update, params: { id: '42', employee_id: '37', project: { these: 'params' } }
+
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
   end
@@ -297,6 +325,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     Project.expects(:find).with('42').returns(mock_project)
     mock_project.expects(:update).with(build_parameters({ 'these' => 'params' })).returns(true)
     put :update, params: { id: '42', manager_id: '37', employee_id: '13', project: { these: 'params' } }
+
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
@@ -310,6 +339,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_project.expects(:destroy).returns(true)
 
     delete :destroy, params: { id: '42', student_id: '37' }
+
     assert_equal mock_student, assigns(:student)
     assert_equal mock_project, assigns(:project)
   end
@@ -321,6 +351,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_project.expects(:destroy).returns(true)
 
     delete :destroy, params: { id: '42', manager_id: '37' }
+
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_project, assigns(:project)
   end
@@ -332,6 +363,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_project.expects(:destroy).returns(true)
 
     delete :destroy, params: { id: '42', employee_id: '37' }
+
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
   end
@@ -345,6 +377,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_project.expects(:destroy).returns(true)
 
     delete :destroy, params: { id: '42', manager_id: '37', employee_id: '13' }
+
     assert_equal mock_manager, assigns(:manager)
     assert_equal mock_employee, assigns(:employee)
     assert_equal mock_project, assigns(:project)
@@ -355,6 +388,7 @@ class MultipleNestedOptionalTest < ActionController::TestCase
     mock_project.expects(:destroy).returns(true)
 
     delete :destroy, params: { id: '42' }
+
     assert_equal mock_project, assigns(:project)
   end
 

--- a/test/nested_model_with_shallow_test.rb
+++ b/test/nested_model_with_shallow_test.rb
@@ -66,6 +66,7 @@ class NestedModelWithShallowTest < ActionController::TestCase
     Speciality.expects(:find).with('37').twice.returns(mock_speciality)
     Plan::Group.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_group(save: true))
     post :create, params: { speciality_id: '37', group: {'these' => 'params'} }
+
     assert_equal mock_group, assigns(:group)
   end
 
@@ -73,6 +74,7 @@ class NestedModelWithShallowTest < ActionController::TestCase
     should_find_parents
     mock_group.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     post :update, params: { id: 'forty_two', group: {'these' => 'params'} }
+
     assert_equal mock_group, assigns(:group)
   end
 

--- a/test/nested_singleton_test.rb
+++ b/test/nested_singleton_test.rb
@@ -70,6 +70,7 @@ class NestedSingletonTest < ActionController::TestCase
     Party.expects(:find).with('37').returns(mock_party)
     mock_party.expects(:venue).returns(mock_venue)
     get :show, params: { party_id: '37' }
+
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
   ensure
@@ -85,6 +86,7 @@ class NestedSingletonTest < ActionController::TestCase
     mock_venue.expects(:address).returns(mock_address)
     mock_address.expects(:geolocation).returns(mock_geolocation)
     get :show, params: { party_id: '37' }
+
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)
@@ -98,6 +100,7 @@ class NestedSingletonTest < ActionController::TestCase
     mock_party.expects(:venue).returns(mock_venue)
     mock_venue.expects(:build_address).returns(mock_address)
     get :new, params: { party_id: '37' }
+
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)
@@ -108,6 +111,7 @@ class NestedSingletonTest < ActionController::TestCase
     mock_party.expects(:venue).returns(mock_venue)
     mock_venue.expects(:address).returns(mock_address)
     get :edit, params: { party_id: '37' }
+
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)
@@ -119,6 +123,7 @@ class NestedSingletonTest < ActionController::TestCase
     mock_party.expects(:venue).returns(mock_venue)
     mock_venue.expects(:address).returns(mock_address)
     get :show, params: { party_id: '37' }
+
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)
@@ -130,6 +135,7 @@ class NestedSingletonTest < ActionController::TestCase
     mock_party.expects(:venue).returns(mock_venue)
     mock_venue.expects(:build_address).with(build_parameters({'these' => 'params'})).returns(mock_address(save: true))
     post :create, params: { party_id: '37', address: {these: 'params'} }
+
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)
@@ -140,6 +146,7 @@ class NestedSingletonTest < ActionController::TestCase
     mock_party.expects(:venue).returns(mock_venue(address: mock_address))
     mock_address.expects(:update).with(build_parameters({'these' => 'params'})).returns(mock_address(save: true))
     post :update, params: { party_id: '37', address: {these: 'params'} }
+
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)
@@ -152,6 +159,7 @@ class NestedSingletonTest < ActionController::TestCase
     @controller.expects(:parent_url).returns('http://test.host/')
     mock_address.expects(:destroy)
     delete :destroy, params: { party_id: '37' }
+
     assert_equal mock_party, assigns(:party)
     assert_equal mock_venue, assigns(:venue)
     assert_equal mock_address, assigns(:address)

--- a/test/optional_belongs_to_test.rb
+++ b/test/optional_belongs_to_test.rb
@@ -31,6 +31,7 @@ class OptionalTest < ActionController::TestCase
     mock_category.expects(:products).returns(Product)
     Product.expects(:scoped).returns([mock_product])
     get :index, params: { category_id: '37' }
+
     assert_equal mock_category, assigns(:category)
     assert_equal [mock_product], assigns(:products)
   end
@@ -38,6 +39,7 @@ class OptionalTest < ActionController::TestCase
   def test_expose_all_products_as_instance_variable_without_category
     Product.expects(:scoped).returns([mock_product])
     get :index
+
     assert_nil assigns(:category)
     assert_equal [mock_product], assigns(:products)
   end
@@ -47,6 +49,7 @@ class OptionalTest < ActionController::TestCase
     mock_category.expects(:products).returns(Product)
     Product.expects(:find).with('42').returns(mock_product)
     get :show, params: { id: '42', category_id: '37' }
+
     assert_equal mock_category, assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -54,6 +57,7 @@ class OptionalTest < ActionController::TestCase
   def test_expose_the_requested_product_without_category
     Product.expects(:find).with('42').returns(mock_product)
     get :show, params: { id: '42' }
+
     assert_nil assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -63,6 +67,7 @@ class OptionalTest < ActionController::TestCase
     mock_category.expects(:products).returns(Product)
     Product.expects(:build).returns(mock_product)
     get :new, params: { category_id: '37' }
+
     assert_equal mock_category, assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -70,6 +75,7 @@ class OptionalTest < ActionController::TestCase
   def test_expose_a_new_product_without_category
     Product.expects(:new).returns(mock_product)
     get :new
+
     assert_nil assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -79,6 +85,7 @@ class OptionalTest < ActionController::TestCase
     mock_category.expects(:products).returns(Product)
     Product.expects(:find).with('42').returns(mock_product)
     get :edit, params: { id: '42', category_id: '37' }
+
     assert_equal mock_category, assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -86,6 +93,7 @@ class OptionalTest < ActionController::TestCase
   def test_expose_the_requested_product_for_edition_without_category
     Product.expects(:find).with('42').returns(mock_product)
     get :edit, params: { id: '42' }
+
     assert_nil assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -95,6 +103,7 @@ class OptionalTest < ActionController::TestCase
     mock_category.expects(:products).returns(Product)
     Product.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_product(save: true))
     post :create, params: { category_id: '37', product: {these: 'params'} }
+
     assert_equal mock_category, assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -102,6 +111,7 @@ class OptionalTest < ActionController::TestCase
   def test_expose_a_newly_create_product_without_category
     Product.expects(:new).with(build_parameters({'these' => 'params'})).returns(mock_product(save: true))
     post :create, params: { product: {these: 'params'} }
+
     assert_nil assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -113,6 +123,7 @@ class OptionalTest < ActionController::TestCase
     mock_product.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
 
     put :update, params: { id: '42', category_id: '37', product: {these: 'params'} }
+
     assert_equal mock_category, assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -122,6 +133,7 @@ class OptionalTest < ActionController::TestCase
     mock_product.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
 
     put :update, params: { id: '42', product: {these: 'params'} }
+
     assert_nil assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -134,6 +146,7 @@ class OptionalTest < ActionController::TestCase
     @controller.expects(:collection_url).returns('/')
 
     delete :destroy, params: { id: '42', category_id: '37' }
+
     assert_equal mock_category, assigns(:category)
     assert_equal mock_product, assigns(:product)
   end
@@ -144,6 +157,7 @@ class OptionalTest < ActionController::TestCase
     @controller.expects(:collection_url).returns('/')
 
     delete :destroy, params: { id: '42' }
+
     assert_nil assigns(:category)
     assert_equal mock_product, assigns(:product)
   end

--- a/test/optional_belongs_to_test.rb
+++ b/test/optional_belongs_to_test.rb
@@ -166,7 +166,7 @@ class OptionalTest < ActionController::TestCase
     Product.expects(:scoped).returns([mock_product])
     get :index
 
-    assert !@controller.send(:parent?)
+    refute @controller.send(:parent?)
     assert_nil assigns(:parent_type)
     assert_nil @controller.send(:parent_type)
     assert_nil @controller.send(:parent_class)

--- a/test/polymorphic_test.rb
+++ b/test/polymorphic_test.rb
@@ -44,6 +44,7 @@ class PolymorphicFactoriesTest < ActionController::TestCase
   def test_expose_all_employees_as_instance_variable_on_index
     Employee.expects(:scoped).returns([mock_employee])
     get :index, params: { factory_id: '37' }
+
     assert_equal mock_factory, assigns(:factory)
     assert_equal [mock_employee], assigns(:employees)
   end
@@ -51,6 +52,7 @@ class PolymorphicFactoriesTest < ActionController::TestCase
   def test_expose_the_requested_employee_on_show
     Employee.expects(:find).with('42').returns(mock_employee)
     get :show, params: { id: '42', factory_id: '37' }
+
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -58,6 +60,7 @@ class PolymorphicFactoriesTest < ActionController::TestCase
   def test_expose_a_new_employee_on_new
     Employee.expects(:build).returns(mock_employee)
     get :new, params: { factory_id: '37' }
+
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -65,6 +68,7 @@ class PolymorphicFactoriesTest < ActionController::TestCase
   def test_expose_the_requested_employee_on_edit
     Employee.expects(:find).with('42').returns(mock_employee)
     get :edit, params: { id: '42', factory_id: '37' }
+
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
     assert_response :success
@@ -73,6 +77,7 @@ class PolymorphicFactoriesTest < ActionController::TestCase
   def test_expose_a_newly_create_employee_on_create
     Employee.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_employee(save: true))
     post :create, params: { factory_id: '37', employee: {these: 'params'} }
+
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -81,6 +86,7 @@ class PolymorphicFactoriesTest < ActionController::TestCase
     Employee.expects(:find).with('42').returns(mock_employee)
     mock_employee.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: '42', factory_id: '37', employee: {these: 'params'} }
+
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -89,6 +95,7 @@ class PolymorphicFactoriesTest < ActionController::TestCase
     Employee.expects(:find).with('42').returns(mock_employee)
     mock_employee.expects(:destroy)
     delete :destroy, params: { id: '42', factory_id: '37' }
+
     assert_equal mock_factory, assigns(:factory)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -144,6 +151,7 @@ class PolymorphicCompanyTest < ActionController::TestCase
   def test_expose_all_employees_as_instance_variable_on_index
     Employee.expects(:scoped).returns([mock_employee])
     get :index, params: { company_id: '37' }
+
     assert_equal mock_company, assigns(:company)
     assert_equal [mock_employee], assigns(:employees)
   end
@@ -151,6 +159,7 @@ class PolymorphicCompanyTest < ActionController::TestCase
   def test_expose_the_requested_employee_on_show
     Employee.expects(:find).with('42').returns(mock_employee)
     get :show, params: { id: '42', company_id: '37' }
+
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -158,6 +167,7 @@ class PolymorphicCompanyTest < ActionController::TestCase
   def test_expose_a_new_employee_on_new
     Employee.expects(:build).returns(mock_employee)
     get :new, params: { company_id: '37' }
+
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -165,6 +175,7 @@ class PolymorphicCompanyTest < ActionController::TestCase
   def test_expose_the_requested_employee_on_edit
     Employee.expects(:find).with('42').returns(mock_employee)
     get :edit, params: { id: '42', company_id: '37' }
+
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)
     assert_response :success
@@ -173,6 +184,7 @@ class PolymorphicCompanyTest < ActionController::TestCase
   def test_expose_a_newly_create_employee_on_create
     Employee.expects(:build).with(build_parameters({'these' => 'params'})).returns(mock_employee(save: true))
     post :create, params: { company_id: '37', employee: {these: 'params'} }
+
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -181,6 +193,7 @@ class PolymorphicCompanyTest < ActionController::TestCase
     Employee.expects(:find).with('42').returns(mock_employee)
     mock_employee.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { id: '42', company_id: '37', employee: {these: 'params'} }
+
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -189,6 +202,7 @@ class PolymorphicCompanyTest < ActionController::TestCase
     Employee.expects(:find).with('42').returns(mock_employee)
     mock_employee.expects(:destroy)
     delete :destroy, params: { id: '42', company_id: '37' }
+
     assert_equal mock_company, assigns(:company)
     assert_equal mock_employee, assigns(:employee)
   end
@@ -239,6 +253,7 @@ class PolymorphicPhotosTest < ActionController::TestCase
 
   def test_parent_as_instance_variable_on_index_when_method_overwritten
     get :index, params: { user_id: '37' }
+
     assert_equal mock_user, assigns(:user)
   end
 

--- a/test/redirect_to_test.rb
+++ b/test/redirect_to_test.rb
@@ -40,18 +40,21 @@ class RedirectToWithBlockTest < ActionController::TestCase
   def test_redirect_to_the_given_url_on_create
     Machine.stubs(:new).returns(mock_machine(save: true))
     post :create
+
     assert_redirected_to 'http://test.host/create'
   end
 
   def test_redirect_to_the_given_url_on_update
     Machine.stubs(:find).returns(mock_machine(update: true))
     put :update, params: { id: '42' }
+
     assert_redirected_to 'http://test.host/update'
   end
 
   def test_redirect_to_the_given_url_on_destroy
     Machine.stubs(:find).returns(mock_machine(destroy: true))
     delete :destroy, params: { id: '42' }
+
     assert_redirected_to 'http://test.host/destroy'
   end
 

--- a/test/singleton_test.rb
+++ b/test/singleton_test.rb
@@ -35,6 +35,7 @@ class SingletonTest < ActionController::TestCase
     Store.expects(:find).with('37').returns(mock_store)
     mock_store.expects(:manager).returns(mock_manager)
     get :show, params: { store_id: '37' }
+
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)
   end
@@ -43,6 +44,7 @@ class SingletonTest < ActionController::TestCase
     Store.expects(:find).with('37').returns(mock_store)
     mock_store.expects(:build_manager).returns(mock_manager)
     get :new, params: { store_id: '37' }
+
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)
   end
@@ -51,6 +53,7 @@ class SingletonTest < ActionController::TestCase
     Store.expects(:find).with('37').returns(mock_store)
     mock_store.expects(:manager).returns(mock_manager)
     get :edit, params: { store_id: '37' }
+
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)
     assert_response :success
@@ -60,6 +63,7 @@ class SingletonTest < ActionController::TestCase
     Store.expects(:find).with('37').returns(mock_store)
     mock_store.expects(:build_manager).with(build_parameters({'these' => 'params'})).returns(mock_manager(save: true))
     post :create, params: { store_id: '37', manager: {these: 'params'} }
+
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)
   end
@@ -68,6 +72,7 @@ class SingletonTest < ActionController::TestCase
     Store.expects(:find).with('37').returns(mock_store(manager: mock_manager))
     mock_manager.expects(:update).with(build_parameters({'these' => 'params'})).returns(true)
     put :update, params: { store_id: '37', manager: {these: 'params'} }
+
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)
   end
@@ -78,6 +83,7 @@ class SingletonTest < ActionController::TestCase
     @controller.expects(:parent_url).returns('http://test.host/')
     mock_manager.expects(:destroy)
     delete :destroy, params: { store_id: '37' }
+
     assert_equal mock_store, assigns(:store)
     assert_equal mock_manager, assigns(:manager)
   end

--- a/test/strong_parameters_test.rb
+++ b/test/strong_parameters_test.rb
@@ -27,17 +27,17 @@ class StrongParametersTest < ActionController::TestCase
     clear_routes
   end
 
-  def test_permitted_params_from_new
+  def test_permitted_params_from_new # rubocop:disable Minitest/NoAssertions
     Widget.expects(:new).with(permitted: 'param')
     get :new, params: { widget: { permitted: 'param', prohibited: 'param' } }
   end
 
-  def test_permitted_params_from_create
+  def test_permitted_params_from_create # rubocop:disable Minitest/NoAssertions
     Widget.expects(:new).with(permitted: 'param').returns(mock(save: true))
     post :create, params: { widget: { permitted: 'param', prohibited: 'param' } }
   end
 
-  def test_permitted_params_from_update
+  def test_permitted_params_from_update # rubocop:disable Minitest/NoAssertions
     mock_widget = mock
     mock_widget.stubs(:class).returns(Widget)
     mock_widget.expects(:update).with(permitted: 'param')
@@ -49,7 +49,7 @@ class StrongParametersTest < ActionController::TestCase
   end
 
   # `permitted_params` has greater priority than `widget_params`
-  def test_with_permitted_and_resource_methods
+  def test_with_permitted_and_resource_methods # rubocop:disable Minitest/NoAssertions
     @controller.stubs(:widget_params).returns(permitted: 'another_param')
     class << @controller
       private :widget_params
@@ -78,17 +78,17 @@ class StrongParametersWithoutPermittedParamsTest < ActionController::TestCase
     clear_routes
   end
 
-  def test_permitted_params_from_new
+  def test_permitted_params_from_new # rubocop:disable Minitest/NoAssertions
     Widget.expects(:new).with(permitted: 'param')
     get :new, params: { widget: { permitted: 'param', prohibited: 'param' } }
   end
 
-  def test_permitted_params_from_create
+  def test_permitted_params_from_create # rubocop:disable Minitest/NoAssertions
     Widget.expects(:new).with(permitted: 'param').returns(mock(save: true))
     post :create, params: { widget: { permitted: 'param', prohibited: 'param' } }
   end
 
-  def test_permitted_params_from_update
+  def test_permitted_params_from_update # rubocop:disable Minitest/NoAssertions
     mock_widget = mock
     mock_widget.stubs(:class).returns(Widget)
     mock_widget.expects(:update).with(permitted: 'param')
@@ -122,22 +122,22 @@ class StrongParametersIntegrationTest < ActionController::TestCase
     clear_routes
   end
 
-  def test_permitted_empty_params_from_new
+  def test_permitted_empty_params_from_new # rubocop:disable Minitest/NoAssertions
     Widget.expects(:new).with({})
     get :new, params: {}
   end
 
-  def test_permitted_params_from_new
+  def test_permitted_params_from_new # rubocop:disable Minitest/NoAssertions
     Widget.expects(:new).with(build_parameters({'permitted' => 'param'}).permit!)
     get :new, params: { widget: { permitted: 'param', prohibited: 'param' } }
   end
 
-  def test_permitted_params_from_create
+  def test_permitted_params_from_create # rubocop:disable Minitest/NoAssertions
     Widget.expects(:new).with(build_parameters({'permitted' => 'param'}).permit!).returns(mock(save: true))
     post :create, params: { widget: { permitted: 'param', prohibited: 'param' } }
   end
 
-  def test_permitted_params_from_update
+  def test_permitted_params_from_update # rubocop:disable Minitest/NoAssertions
     mock_widget = mock
     mock_widget.stubs(:class).returns(Widget)
     mock_widget.expects(:update).with(build_parameters({'permitted' => 'param'}).permit!)

--- a/test/tasks/gemspec_test.rb
+++ b/test/tasks/gemspec_test.rb
@@ -12,6 +12,6 @@ class GemspecTest < Minitest::Test
   end
 
   def test_succeeds
-    assert_equal true, @build[2].success?
+    assert_predicate @build[2], :success?
   end
 end

--- a/test/url_helpers_test.rb
+++ b/test/url_helpers_test.rb
@@ -159,7 +159,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     controller.expects(route)
   end
 
-  def test_url_helpers_on_simple_inherited_resource
+  def test_url_helpers_on_simple_inherited_resource # rubocop:disable Minitest/NoAssertions
     controller = HousesController.new
     controller.instance_variable_set(:@house, :house)
 
@@ -189,7 +189,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_on_simple_inherited_resource_using_uncountable
+  def test_url_helpers_on_simple_inherited_resource_using_uncountable # rubocop:disable Minitest/NoAssertions
     controller = NewsController.new
     controller.instance_variable_set(:@news, :news)
 
@@ -251,7 +251,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_on_simple_inherited_singleton_resource
+  def test_url_helpers_on_simple_inherited_singleton_resource # rubocop:disable Minitest/NoAssertions
     controller = UniversesController.new
     controller.instance_variable_set(:@universe, :universe)
 
@@ -275,7 +275,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_on_singleton_belongs_to
+  def test_url_helpers_on_singleton_belongs_to # rubocop:disable Minitest/NoAssertions
     controller = FlamesController.new
     controller.instance_variable_set(:@house, :house)
     controller.instance_variable_set(:@fireplace, :fireplace)
@@ -307,7 +307,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_on_belongs_to
+  def test_url_helpers_on_belongs_to # rubocop:disable Minitest/NoAssertions
     controller = TablesController.new
     controller.instance_variable_set(:@house, :house)
     controller.instance_variable_set(:@table, :table)
@@ -347,7 +347,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_on_not_default_belongs_to
+  def test_url_helpers_on_not_default_belongs_to # rubocop:disable Minitest/NoAssertions
     controller = RoomsController.new
     controller.instance_variable_set(:@house, :house)
     controller.instance_variable_set(:@room, :room)
@@ -387,7 +387,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_on_nested_belongs_to
+  def test_url_helpers_on_nested_belongs_to # rubocop:disable Minitest/NoAssertions
     controller = ChairsController.new
     controller.instance_variable_set(:@house, :house)
     controller.instance_variable_set(:@table, :table)
@@ -428,7 +428,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_on_singletons_with_belongs_to
+  def test_url_helpers_on_singletons_with_belongs_to # rubocop:disable Minitest/NoAssertions
     controller = OwnersController.new
     controller.instance_variable_set(:@house, :house)
     controller.instance_variable_set(:@owner, :owner)
@@ -459,7 +459,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_on_singleton_and_polymorphic_belongs_to
+  def test_url_helpers_on_singleton_and_polymorphic_belongs_to # rubocop:disable Minitest/NoAssertions
     house = House.new
     dishwasher = Dishwasher.new
     fork = Fork.new
@@ -499,7 +499,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_on_polymorphic_belongs_to
+  def test_url_helpers_on_polymorphic_belongs_to # rubocop:disable Minitest/NoAssertions
     house = House.new
     house.stubs(:persisted?).returns(true)
     bed   = Bed.new
@@ -555,7 +555,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     controller.send(:parent_url, :arg)
   end
 
-  def test_url_helpers_on_polymorphic_belongs_to_using_uncountable
+  def test_url_helpers_on_polymorphic_belongs_to_using_uncountable # rubocop:disable Minitest/NoAssertions
     sheep  = Sheep.new
     sheep.stubs(:persisted?).returns(true)
     news = News.new
@@ -611,7 +611,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     controller.send(:parent_url, :arg)
   end
 
-  def test_url_helpers_on_shallow_belongs_to_using_uncountable
+  def test_url_helpers_on_shallow_belongs_to_using_uncountable # rubocop:disable Minitest/NoAssertions
     fish = Fish.new
     bed  = Bed.new
 
@@ -644,7 +644,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_on_namespaced_polymorphic_belongs_to
+  def test_url_helpers_on_namespaced_polymorphic_belongs_to # rubocop:disable Minitest/NoAssertions
     house = House.new
     house.stubs(:persisted?).returns(true)
     desk  = Desk.new
@@ -700,7 +700,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     controller.send(:parent_url, :arg)
   end
 
-  def test_url_helpers_on_nested_polymorphic_belongs_to
+  def test_url_helpers_on_nested_polymorphic_belongs_to # rubocop:disable Minitest/NoAssertions
     house = House.new
     table = Table.new
     table.stubs(:persisted?).returns(true)
@@ -755,7 +755,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     controller.send(:parent_url, :arg)
   end
 
-  def test_url_helpers_on_singleton_nested_polymorphic_belongs_to
+  def test_url_helpers_on_singleton_nested_polymorphic_belongs_to # rubocop:disable Minitest/NoAssertions
     # This must not be usefull in singleton controllers...
     # Center.new
     house = House.new
@@ -806,7 +806,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     controller.send(:parent_url, :arg)
   end
 
-  def test_url_helpers_on_optional_polymorphic_belongs_to
+  def test_url_helpers_on_optional_polymorphic_belongs_to # rubocop:disable Minitest/NoAssertions
     bed   = Bed.new
     bed.stubs(:persisted?).returns(true)
     new_bed = Bed.new
@@ -843,7 +843,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     controller.send(:edit_resource_url, :arg)
   end
 
-  def test_url_helpers_on_belongs_to_with_shallowed_route
+  def test_url_helpers_on_belongs_to_with_shallowed_route # rubocop:disable Minitest/NoAssertions
     controller = MirrorsController.new
     controller.instance_variable_set(:@house, :house)
     controller.instance_variable_set(:@mirror, :mirror)
@@ -869,7 +869,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_on_nested_belongs_to_with_shallowed_route
+  def test_url_helpers_on_nested_belongs_to_with_shallowed_route # rubocop:disable Minitest/NoAssertions
     controller = ButtonsController.new
     controller.instance_variable_set(:@display, :display)
     controller.instance_variable_set(:@window, :window)
@@ -896,7 +896,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_with_custom_actions
+  def test_url_helpers_with_custom_actions # rubocop:disable Minitest/NoAssertions
     controller = ButtonsController.new
     controller.instance_variable_set(:@display, :display)
     controller.instance_variable_set(:@window, :window)
@@ -919,7 +919,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
   end
 
-  def test_helpers_on_inherited_controller
+  def test_helpers_on_inherited_controller # rubocop:disable Minitest/NoAssertions
     controller = ImageButtonsController.new
     controller.expects("edit_image_button_path").once
     controller.send(:edit_resource_path)
@@ -927,7 +927,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     controller.send(:delete_resource_path)
   end
 
-  def test_url_helpers_on_namespaced_resource_with_shallowed_route
+  def test_url_helpers_on_namespaced_resource_with_shallowed_route # rubocop:disable Minitest/NoAssertions
     controller = Admin::MirrorsController.new
     controller.instance_variable_set(:@house, :house)
     controller.instance_variable_set(:@mirror, :mirror)
@@ -954,7 +954,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
   end
 
-  def test_url_helpers_with_action_controller_parameters
+  def test_url_helpers_with_action_controller_parameters # rubocop:disable Minitest/NoAssertions
     parameters = ActionController::Parameters.new(page: 2)
     parameters.permit!
 

--- a/test/url_helpers_test.rb
+++ b/test/url_helpers_test.rb
@@ -914,8 +914,8 @@ class UrlHelpersTest < ActiveSupport::TestCase
     controller = ButtonsController.new
     helper_methods = controller.class._helpers.instance_methods.map {|m| m.to_s }
     [:url, :path].each do |path_or_url|
-      assert helper_methods.include?("delete_resource_#{path_or_url}")
-      assert helper_methods.include?("search_resources_#{path_or_url}")
+      assert_includes helper_methods, "delete_resource_#{path_or_url}"
+      assert_includes helper_methods, "search_resources_#{path_or_url}"
     end
   end
 


### PR DESCRIPTION
There are 37 `Minitest/NoAssertions` offenses left.

This is due to the fact that there are mocha expectations instead of "assert".

Example:

```rb
  def test_url_helpers_are_recreated_when_defaults_change
    BooksController.expects(:create_resources_url_helpers!).returns(true).once
    BooksController.send(:defaults, instance_name: 'string', collection_name: 'strings')
  end
```

No asserts here

The solution would be to:
- Disable this cop, but we may miss real offenses
- Add `assert true`