### PR TITLE
Silence mocha deprecations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development do
   gem 'rails-controller-testing'
   gem 'simplecov', require: false
   gem 'simplecov-cobertura'
+  gem 'warning'
 end
 
 group :rubocop do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,6 +252,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    warning (1.3.0)
     webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -278,6 +279,7 @@ DEPENDENCIES
   rubocop-performance
   simplecov
   simplecov-cobertura
+  warning
 
 BUNDLED WITH
    2.4.8

--- a/gemfiles/rails_61/Gemfile
+++ b/gemfiles/rails_61/Gemfile
@@ -11,4 +11,5 @@ group :development do
   gem 'rails-controller-testing'
   gem 'simplecov', require: false
   gem 'simplecov-cobertura'
+  gem 'warning'
 end

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -188,6 +188,7 @@ GEM
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    warning (1.3.0)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-driver (0.7.6-java)
@@ -210,6 +211,7 @@ DEPENDENCIES
   rails-controller-testing
   simplecov
   simplecov-cobertura
+  warning
 
 BUNDLED WITH
    2.4.8

--- a/gemfiles/rails_70/Gemfile
+++ b/gemfiles/rails_70/Gemfile
@@ -11,4 +11,5 @@ group :development do
   gem 'rails-controller-testing'
   gem 'simplecov', require: false
   gem 'simplecov-cobertura'
+  gem 'warning'
 end

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -187,6 +187,7 @@ GEM
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    warning (1.3.0)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-driver (0.7.6-java)
@@ -209,6 +210,7 @@ DEPENDENCIES
   rails-controller-testing
   simplecov
   simplecov-cobertura
+  warning
 
 BUNDLED WITH
    2.4.8

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,10 @@ require "active_support"
 require "active_model"
 require "action_controller"
 
+# TODO: Remove warning gem and the following lines when freerange/mocha#593 will be fixed
+require "warning"
+Warning.ignore(/Mocha deprecation warning .+ expected keyword arguments .+ but received positional hash/)
+
 require 'rails-controller-testing'
 Rails::Controller::Testing.install
 


### PR DESCRIPTION
Deprecation warnings are incorrect because there is a misunderstanding
around the Ruby keyword arguments change in 3.0.

Ref: https://github.com/freerange/mocha/issues/593

Close https://github.com/activeadmin/inherited_resources/issues/876