### PR TITLE
Inline required workflows for GHA

### DIFF
--- a/.github/workflows/github-actions-lint.yml
+++ b/.github/workflows/github-actions-lint.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions Lint
+
+on:
+  pull_request:
+
+jobs:
+  github_actions_lint:
+    name: Run actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@v41
+        id: changed-files
+        with:
+          files: |
+            .github/workflows/*.yaml
+            .github/workflows/*.yml
+      - uses: reviewdog/action-actionlint@v1
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          fail_on_error: true
+          filter_mode: nofilter # added (default), diff_context, file, nofilter
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,41 @@
+name: Rubocop
+
+on:
+  pull_request:
+
+env:
+  RUBY_VERSION: ${{ vars.RUBOCOP_RUBY_VERSION || '3.2' }}
+
+jobs:
+  rubocop:
+    name: Run rubocop
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_ONLY: ${{ vars.RUBOCOP_BUNDLE_ONLY || 'rubocop' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@v41
+        id: changed-files
+        with:
+          files: |
+            .github/workflows/rubocop.yml
+            .rubocop.yml
+            **.rb
+            bin/*
+            gemfiles/**/Gemfile
+            Gemfile*
+            Rakefile
+            *.gemspec
+      - uses: ruby/setup-ruby@v1
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+      - uses: reviewdog/action-rubocop@v2
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          fail_on_error: true
+          filter_mode: nofilter # added (default), diff_context, file, nofilter
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          skip_install: true
+          use_bundler: true

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,0 +1,24 @@
+name: YAML Lint
+
+on:
+  pull_request:
+
+jobs:
+  yaml_lint:
+    name: Run yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@v41
+        id: changed-files
+        with:
+          files: |
+            **.yaml
+            **.yml
+      - uses: reviewdog/action-yamllint@v1
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          fail_on_error: true
+          filter_mode: nofilter # added (default), diff_context, file, nofilter
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check


### PR DESCRIPTION
We were using GitHub's Required Workflows feature but it has been fully deprecated as of Jan 2024 and would need an Enterprise plan to use. Best overall to just inline these per repository.