### PR TITLE
Support setting parent_controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ class AccountsController < ApplicationController
 end
 ```
 
+By default, `InheritedResources::Base` will inherit from `::ApplicationController`. You can change this in a rails initializer:
+
+```ruby
+# config/initializers/inherited_resources.rb
+InheritedResources.parent_controller = 'MyController'
+```
+
 ## Overwriting defaults
 
 Whenever you inherit from InheritedResources, several defaults are assumed.

--- a/app/controllers/inherited_resources/base.rb
+++ b/app/controllers/inherited_resources/base.rb
@@ -9,7 +9,7 @@ module InheritedResources
   # call <tt>default</tt> class method, call <<tt>actions</tt> class method
   # or overwrite some helpers in the base_helpers.rb file.
   #
-  class Base < ::ApplicationController
+  class Base < InheritedResources.parent_controller.constantize
     # Overwrite inherit_resources to add specific InheritedResources behavior.
     def self.inherit_resources(base)
       base.class_eval do

--- a/lib/inherited_resources.rb
+++ b/lib/inherited_resources.rb
@@ -26,6 +26,10 @@ module InheritedResources
   def self.flash_keys=(array)
     Responders::FlashResponder.flash_keys = array
   end
+
+  # Inherit from a different controller. This only has an effect if changed
+  # before InheritedResources::Base is loaded, e.g. in a rails initializer.
+  mattr_accessor(:parent_controller) { '::ApplicationController' }
 end
 
 ActiveSupport.on_load(:action_controller_base) do

--- a/test/parent_controller_test.rb
+++ b/test/parent_controller_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+def force_parent_controller(value)
+  InheritedResources.send(:remove_const, :Base)
+  InheritedResources.parent_controller = value
+  load File.join(__dir__, '..', 'app', 'controllers', 'inherited_resources', 'base.rb')
+end
+
+class ParentControllerTest < ActionController::TestCase
+  def test_setting_parent_controller
+    original_parent = InheritedResources::Base.superclass
+
+    assert_equal ApplicationController, original_parent
+
+    force_parent_controller('ActionController::Base')
+
+    assert_equal ActionController::Base, InheritedResources::Base.superclass
+  ensure
+    force_parent_controller(original_parent.to_s) # restore original parent
+  end
+end

--- a/test/parent_controller_test.rb
+++ b/test/parent_controller_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 def force_parent_controller(value)


### PR DESCRIPTION
fixes #618

for the interface, i mirrored `Devise::parent_controller=`.