### PR TITLE
Configure Minitest/Focus cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,6 +119,9 @@ Minitest/DuplicateTestRun:
 Minitest/EmptyLineBeforeAssertionMethods:
   Enabled: true
 
+Minitest/Focus:
+  Enabled: true
+
 Minitest/GlobalExpectations:
   Enabled: true
 


### PR DESCRIPTION
Added in v0.35, prevents a warning in the console