### PR TITLE
Add frozen string literal magic comment (potential breaking change)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -373,5 +373,13 @@ Performance/UnfreezeString:
 Performance/UriDefaultParser:
   Enabled: true
 
+Style/Encoding:
+  Enabled: true
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  Exclude:
+    - bin/console
+
 Style/HashSyntax:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Version 2.0.0
 
 * Test against Rails 7.2 [#921][].
+* Add frozen string literal to `InheritedResources` module [#933][].
 * Change return codes to new Responders defaults [#918][].
 
 ## Version 1.14.0
@@ -234,3 +235,4 @@ _No changes_.
 [#873]: https://github.com/activeadmin/inherited_resources/pull/873
 [#918]: https://github.com/activeadmin/inherited_resources/pull/918
 [#921]: https://github.com/activeadmin/inherited_resources/pull/921
+[#933]: https://github.com/activeadmin/inherited_resources/pull/933

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gemspec path: '.'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rdoc/task'

--- a/app/controllers/inherited_resources/base.rb
+++ b/app/controllers/inherited_resources/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module InheritedResources
   # = Base
   #

--- a/gemfiles/rails_61/Gemfile
+++ b/gemfiles/rails_61/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gemspec path: '../..'

--- a/gemfiles/rails_70/Gemfile
+++ b/gemfiles/rails_70/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gemspec path: '../..'

--- a/gemfiles/rails_71/Gemfile
+++ b/gemfiles/rails_71/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gemspec path: '../..'

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inherited_resources/version"

--- a/lib/inherited_resources/version.rb
+++ b/lib/inherited_resources/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module InheritedResources
   VERSION = '2.0.0'.freeze
 end

--- a/test/aliases_test.rb
+++ b/test/aliases_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Student

--- a/test/association_chain_test.rb
+++ b/test/association_chain_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Pet

--- a/test/autoload/engine.rb
+++ b/test/autoload/engine.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module MyTestNamespace
   class Engine; end
 end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class User

--- a/test/belongs_to_test.rb
+++ b/test/belongs_to_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Post

--- a/test/belongs_to_with_shallow_test.rb
+++ b/test/belongs_to_with_shallow_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Post

--- a/test/changelog_test.rb
+++ b/test/changelog_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class ChangelogTest < ActiveSupport::TestCase

--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Book; end

--- a/test/customized_base_test.rb
+++ b/test/customized_base_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Car

--- a/test/customized_belongs_to_test.rb
+++ b/test/customized_belongs_to_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class GreatSchool

--- a/test/customized_redirect_to_test.rb
+++ b/test/customized_redirect_to_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Post;

--- a/test/defaults_test.rb
+++ b/test/defaults_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Malarz

--- a/test/multiple_nested_optional_belongs_to_test.rb
+++ b/test/multiple_nested_optional_belongs_to_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Student; end

--- a/test/nested_belongs_to_test.rb
+++ b/test/nested_belongs_to_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Country

--- a/test/nested_belongs_to_with_shallow_test.rb
+++ b/test/nested_belongs_to_with_shallow_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Dresser

--- a/test/nested_model_with_shallow_test.rb
+++ b/test/nested_model_with_shallow_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Subfaculty

--- a/test/nested_singleton_test.rb
+++ b/test/nested_singleton_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 # This test file is instead to test the how controller flow and actions

--- a/test/optional_belongs_to_test.rb
+++ b/test/optional_belongs_to_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Brands; end

--- a/test/polymorphic_test.rb
+++ b/test/polymorphic_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Factory; end

--- a/test/redirect_to_test.rb
+++ b/test/redirect_to_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Machine;

--- a/test/singleton_test.rb
+++ b/test/singleton_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 # This test file is instead to test the how controller flow and actions

--- a/test/strong_parameters_test.rb
+++ b/test/strong_parameters_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class Widget

--- a/test/tasks/gemfile_test.rb
+++ b/test/tasks/gemfile_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "minitest"
 
 class GemfilesTest < Minitest::Test

--- a/test/tasks/gemspec_test.rb
+++ b/test/tasks/gemspec_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "minitest"
 require "open3"
 require "inherited_resources/version"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 if ENV.fetch('COVERAGE', false)
   require 'simplecov'
   require 'simplecov-cobertura'

--- a/test/url_helpers_test.rb
+++ b/test/url_helpers_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class ModelBase


### PR DESCRIPTION
This cop was disabled probably by mistake, since it is present in both
Arbre and Active Admin gems

The only production code affected is:
- app/controllers/inherited_resources/base.rb
- lib/inherited_resources/version.rb

Change to `version.rb` is safe.

After inspecting the source code of `InheritedResources` module, the
change seems safe, but it can represent a breaking change in third-party application.

Since we are bumping the major version number, it would be fine to break
if documented.

Fixed with `rubocop -A`

Also adds `Style/Encoding` cop for parity with Arbre