### PR TITLE
Prefer require_relative for internal requires

### DIFF
--- a/lib/inherited_resources.rb
+++ b/lib/inherited_resources.rb
@@ -3,9 +3,10 @@
 # This is here because responders don't require it.
 require 'rails/engine'
 require 'responders'
-require 'inherited_resources/engine'
-require 'inherited_resources/blank_slate'
-require 'inherited_resources/responder'
+
+require_relative 'inherited_resources/engine'
+require_relative 'inherited_resources/blank_slate'
+require_relative 'inherited_resources/responder'
 
 module InheritedResources
   ACTIONS = [ :index, :show, :new, :edit, :create, :update, :destroy ] unless self.const_defined?(:ACTIONS)

--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Whenever base is required load the dumb responder since it's used inside actions.
-require 'inherited_resources/blank_slate'
+require_relative 'blank_slate'
 
 module InheritedResources
   # Base helpers for InheritedResource work. Some methods here can be overwritten


### PR DESCRIPTION
`require_relative` is preferred over `require` for files within the same project because it uses paths relative to the current file, making code more portable and less dependent on the load path.

This change updates internal requires to use `require_relative` for consistency, performance, and improved portability.

Ref:
- activeadmin/arbre#622