### PR TITLE
Refactor polymorphic keys method

### DIFF
--- a/lib/inherited_resources/polymorphic_helpers.rb
+++ b/lib/inherited_resources/polymorphic_helpers.rb
@@ -153,9 +153,9 @@ module InheritedResources
           if symbol == :polymorphic
             params_keys = params.keys
 
-            keys = polymorphic_config[:symbols].map do |poly|
-              params_keys.include?(resources_configuration[poly][:param].to_s) ? poly : nil
-            end.compact
+            keys = polymorphic_config[:symbols].select do |poly|
+              params_keys.include?(resources_configuration[poly][:param].to_s)
+            end
 
             if keys.empty?
               raise ScriptError, "Could not find param for polymorphic association. The request " <<


### PR DESCRIPTION
Use `select` instead of `map.compact` to:
- Eliminate unnecessary object creation and array compaction
- Maintain identical functionality
- Improve readability and performance

```
Comparison (IPS):
                keys:  1716164.8 i/s
            keys_old:  1531182.7 i/s - 1.12x  (± 0.00) slower

Comparison (Memory):
                keys:        120 allocated
            keys_old:        160 allocated - 1.33x more
```