### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,9 @@ group :development do
   gem 'simplecov', require: false
   gem 'simplecov-cobertura'
   gem 'warning'
+
+  # FIXME: relax this dependency when Ruby 3.1 support will be dropped
+  gem "zeitwerk", "~> 2.6.18"
 end
 
 group :rubocop do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
-    irb (1.14.0)
+    irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.7.2)
@@ -204,7 +204,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.7)
+    rexml (3.3.8)
     rubocop (1.66.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -272,6 +272,7 @@ DEPENDENCIES
   simplecov
   simplecov-cobertura
   warning
+  zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.5.19
+   2.5.21

--- a/gemfiles/rails_61/Gemfile
+++ b/gemfiles/rails_61/Gemfile
@@ -13,4 +13,7 @@ group :development do
   gem 'simplecov', require: false
   gem 'simplecov-cobertura'
   gem 'warning'
+
+  # FIXME: relax this dependency when Ruby 3.1 support will be dropped
+  gem "zeitwerk", "~> 2.6.18"
 end

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.7)
+    rexml (3.3.8)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     simplecov (0.22.0)
@@ -210,6 +210,7 @@ DEPENDENCIES
   simplecov
   simplecov-cobertura
   warning
+  zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.5.19
+   2.5.21

--- a/gemfiles/rails_70/Gemfile
+++ b/gemfiles/rails_70/Gemfile
@@ -13,4 +13,7 @@ group :development do
   gem 'simplecov', require: false
   gem 'simplecov-cobertura'
   gem 'warning'
+
+  # FIXME: relax this dependency when Ruby 3.1 support will be dropped
+  gem "zeitwerk", "~> 2.6.18"
 end

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.7)
+    rexml (3.3.8)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     simplecov (0.22.0)
@@ -209,6 +209,7 @@ DEPENDENCIES
   simplecov
   simplecov-cobertura
   warning
+  zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.5.19
+   2.5.21

--- a/gemfiles/rails_71/Gemfile
+++ b/gemfiles/rails_71/Gemfile
@@ -13,4 +13,7 @@ group :development do
   gem 'simplecov', require: false
   gem 'simplecov-cobertura'
   gem 'warning'
+
+  # FIXME: relax this dependency when Ruby 3.1 support will be dropped
+  gem "zeitwerk", "~> 2.6.18"
 end

--- a/gemfiles/rails_71/Gemfile.lock
+++ b/gemfiles/rails_71/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
-    irb (1.14.0)
+    irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     loofah (2.22.0)
@@ -199,7 +199,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.7)
+    rexml (3.3.8)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     simplecov (0.22.0)
@@ -240,6 +240,7 @@ DEPENDENCIES
   simplecov
   simplecov-cobertura
   warning
+  zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.5.19
+   2.5.21


### PR DESCRIPTION
Pin zeitwerk to `~> 2.6.18` because 2.7.0 only supports Ruby >= 3.2