### PR TITLE
Enable some `Lint` cops to prevent warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,15 @@ Layout/TrailingWhitespace:
 Layout/TrailingEmptyLines:
   Enabled: true
 
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+
+Lint/UselessAssignment:
+  Enabled: true
+
 Minitest:
   Enabled: true
 

--- a/lib/inherited_resources/base_helpers.rb
+++ b/lib/inherited_resources/base_helpers.rb
@@ -297,7 +297,7 @@ module InheritedResources
         if respond_to? :show
           url = resource_url rescue nil
         end
-        url ||= smart_collection_url
+        url || smart_collection_url
       end
 
       # URL to redirect to when redirect implies collection url.
@@ -309,7 +309,7 @@ module InheritedResources
         if respond_to? :parent, true
           url ||= parent_url rescue nil
         end
-        url ||= root_url rescue nil
+        url || root_url rescue nil
       end
 
       # memoize the extraction of attributes from params


### PR DESCRIPTION
Parity with ActiveAdmin to prevent introduction of new warnings

Manually fix a `Lint/UselessAssignment` warning

Ref: https://github.com/activeadmin/activeadmin/issues/8597