### PR TITLE
Update dependencies and improve Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,15 +18,6 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: bundler
-    directory: /gemfiles/rails_61
-    schedule:
-      interval: monthly
-    versioning-strategy: lockfile-only
-    groups:
-      rails_61:
-        patterns:
-          - "*"
-  - package-ecosystem: bundler
     directory: /gemfiles/rails_70
     schedule:
       interval: monthly
@@ -35,3 +26,40 @@ updates:
       rails_70:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: rails
+        versions: ">= 7.1.0"
+      - dependency-name: railties
+        versions: ">= 7.1.0"
+  - package-ecosystem: bundler
+    directory: /gemfiles/rails_71
+    schedule:
+      interval: monthly
+    versioning-strategy: lockfile-only
+    groups:
+      rails_71:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: erb
+        versions: ">= 5"
+      - dependency-name: rails
+        versions: ">= 7.2.0"
+      - dependency-name: railties
+        versions: ">= 7.2.0"
+  - package-ecosystem: bundler
+    directory: /gemfiles/rails_72
+    schedule:
+      interval: monthly
+    versioning-strategy: lockfile-only
+    groups:
+      rails_72:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: erb
+        versions: ">= 5"
+      - dependency-name: rails
+        versions: ">= 8.0.0"
+      - dependency-name: railties
+        versions: ">= 8.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
       ruby-progressbar
     mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -206,7 +206,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.0)
-    rdoc (6.14.0)
+    rdoc (6.14.1)
       erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
@@ -216,7 +216,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.4.1)
-    rubocop (1.76.0)
+    rubocop (1.77.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -224,10 +224,10 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.45.0, < 2.0)
+      rubocop-ast (>= 1.45.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.45.0)
+    rubocop-ast (1.45.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     rubocop-minitest (0.38.1)

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
       ruby-progressbar
     mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)

--- a/gemfiles/rails_71/Gemfile.lock
+++ b/gemfiles/rails_71/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
     mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
     mutex_m (0.3.0)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -205,7 +205,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.3.0)
-    rdoc (6.14.0)
+    rdoc (6.14.1)
       erb
       psych (>= 4.0.0)
     reline (0.6.1)

--- a/gemfiles/rails_72/Gemfile.lock
+++ b/gemfiles/rails_72/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       ruby-progressbar
     mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -198,7 +198,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.3.0)
-    rdoc (6.14.0)
+    rdoc (6.14.1)
       erb
       psych (>= 4.0.0)
     reline (0.6.1)

--- a/inherited_resources.gemspec
+++ b/inherited_resources.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.1'
 
-  s.add_dependency("responders", ">= 2")
   s.add_dependency("actionpack", ">= 7.0")
+  s.add_dependency("has_scope", ">= 0.6")
   s.add_dependency("railties", ">= 7.0")
-  s.add_dependency("has_scope",  ">= 0.6")
+  s.add_dependency("responders", ">= 2")
 end


### PR DESCRIPTION
- Remove Rails 6.1, which is not supported anymore
- Add new Rails versions
- Sort dependencies alphabetically

Similar to activeadmin/arbre#683