### PR TITLE
Use `:unprocessable_content` as error status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 3.0.0
+
+* Change default error code to `:unprocessable_content` [#968][]
+
 ## Version 2.1.0
 
 * Support for setting the parent controller class [#903][]
@@ -248,3 +252,4 @@ _No changes_
 [#933]: https://github.com/activeadmin/inherited_resources/pull/933
 [#939]: https://github.com/activeadmin/inherited_resources/pull/939
 [#942]: https://github.com/activeadmin/inherited_resources/pull/942
+[#968]: https://github.com/activeadmin/inherited_resources/pull/968

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    inherited_resources (2.1.0)
+    inherited_resources (3.0.0)
       actionpack (>= 7.0)
       has_scope (>= 0.6)
       railties (>= 7.0)
@@ -85,7 +85,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     benchmark (0.4.1)
-    bigdecimal (3.2.2)
+    bigdecimal (3.2.3)
     builder (3.3.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
@@ -163,7 +163,7 @@ GEM
       date
       stringio
     racc (1.8.1)
-    rack (3.2.0)
+    rack (3.2.1)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -216,7 +216,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.4.2)
-    rubocop (1.80.1)
+    rubocop (1.80.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ Or install it yourself with:
 $ gem install inherited_resources
 ```
 
+## Upgrading to 3.x from an older version
+
+Starting from version 3.0, InheritedResources uses `:unprocessable_content` as
+the default error status for unprocessable requests, following updates in
+[Rack 3.1.0](https://github.com/rack/rack/pull/2137).
+
+If you are using a version of Rack older than 3.1.0, you can restore the
+previous behavior by configuring:
+
+```ruby
+InheritedResources.error_status = :unprocessable_entity
+```
+
 ## HasScope
 
 Since Inherited Resources 1.0, has_scope is not part of its core anymore but

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    inherited_resources (2.1.0)
+    inherited_resources (3.0.0)
       actionpack (>= 7.0)
       has_scope (>= 0.6)
       railties (>= 7.0)

--- a/gemfiles/rails_71/Gemfile.lock
+++ b/gemfiles/rails_71/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    inherited_resources (2.1.0)
+    inherited_resources (3.0.0)
       actionpack (>= 7.0)
       has_scope (>= 0.6)
       railties (>= 7.0)
@@ -90,7 +90,7 @@ GEM
     ansi (1.5.0)
     base64 (0.3.0)
     benchmark (0.4.1)
-    bigdecimal (3.2.2)
+    bigdecimal (3.2.3)
     builder (3.3.0)
     cgi (0.5.0)
     concurrent-ruby (1.3.5)
@@ -163,7 +163,7 @@ GEM
       date
       stringio
     racc (1.8.1)
-    rack (3.2.0)
+    rack (3.2.1)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)

--- a/gemfiles/rails_72/Gemfile.lock
+++ b/gemfiles/rails_72/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    inherited_resources (2.1.0)
+    inherited_resources (3.0.0)
       actionpack (>= 7.0)
       has_scope (>= 0.6)
       railties (>= 7.0)
@@ -84,7 +84,7 @@ GEM
     ansi (1.5.0)
     base64 (0.3.0)
     benchmark (0.4.1)
-    bigdecimal (3.2.2)
+    bigdecimal (3.2.3)
     builder (3.3.0)
     cgi (0.5.0)
     concurrent-ruby (1.3.5)

--- a/lib/inherited_resources/responder.rb
+++ b/lib/inherited_resources/responder.rb
@@ -4,7 +4,7 @@ module InheritedResources
   class Responder < ActionController::Responder
     include Responders::FlashResponder
 
-    self.error_status = :unprocessable_entity
+    self.error_status = :unprocessable_content
     self.redirect_status = :see_other
   end
 end

--- a/lib/inherited_resources/version.rb
+++ b/lib/inherited_resources/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module InheritedResources
-  VERSION = '2.1.0'.freeze
+  VERSION = '3.0.0'.freeze
 end

--- a/test/aliases_test.rb
+++ b/test/aliases_test.rb
@@ -108,7 +108,7 @@ class AliasesTest < ActionController::TestCase
     @controller.stubs(:resource_url).returns('http://test.host/')
     post :create
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_equal "New HTML", @response.body.strip
   end
 
@@ -118,7 +118,7 @@ class AliasesTest < ActionController::TestCase
     @controller.stubs(:resource_url).returns('http://test.host/')
     post :create
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_equal "New HTML", @response.body.strip
   end
 

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -247,7 +247,7 @@ class CreateActionBaseTest < ActionController::TestCase
     User.stubs(:new).returns(mock_user(save: false, errors: {some: :error}))
     post :create
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_equal "New HTML", @response.body.strip
   end
 
@@ -323,7 +323,7 @@ class UpdateActionBaseTest < ActionController::TestCase
     User.stubs(:find).returns(mock_user(update: false, errors: {some: :error}))
     put :update, params: { id: '42' }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_equal "Edit HTML", @response.body.strip
   end
 
@@ -371,7 +371,7 @@ class DestroyActionBaseTest < ActionController::TestCase
     User.stubs(:find).returns(mock_user(destroy: false, errors: { fail: true }))
     delete :destroy, params: { id: '42' }, format: :js
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_equal 'User could not be destroyed.', flash[:alert]
   end
 

--- a/test/customized_base_test.rb
+++ b/test/customized_base_test.rb
@@ -142,7 +142,7 @@ class CreateActionCustomizedBaseTest < ActionController::TestCase
     Car.stubs(:create_new).returns(mock_car(save_successfully: false, errors: {some: :error}))
     post :create
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_equal "New HTML", @response.body.strip
   end
 end
@@ -170,7 +170,7 @@ class UpdateActionCustomizedBaseTest < ActionController::TestCase
     Car.stubs(:get).returns(mock_car(update_successfully: false, errors: {some: :error}))
     put :update, params: { id: '42' }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_equal "Edit HTML", @response.body.strip
   end
 end


### PR DESCRIPTION
```
Status code :unprocessable_entity is deprecated and will be removed in
a future version of Rack
```

Close #967