### PR TITLE
Test supported Rails versions against Ruby 4.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.1"
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
         rails:
           - rails_70
           - rails_71
@@ -25,8 +27,18 @@ jobs:
           - rails_80
           - rails_81
         exclude:
+          - ruby: "3.1"
+            rails: rails_80
+          - ruby: "3.1"
+            rails: rails_81
           - ruby: "3.4"
             rails: rails_70
+          - ruby: "4.0"
+            rails: rails_70
+          - ruby: "4.0"
+            rails: rails_71
+          - ruby: "4.0"
+            rails: rails_72
     steps:
       - uses: actions/checkout@v6
       - name: Configure bundler (default)

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec path: '.'
 group :development do
   gem 'rails', '~> 8.1.0'
 
-  gem 'mocha'
+  gem 'mocha', '~> 2.8' # TODO: relax this dependency after fixing #981
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,33 +87,33 @@ GEM
     ansi (1.5.0)
     ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (3.3.1)
+    bigdecimal (4.0.1)
     builder (3.3.0)
-    concurrent-ruby (1.3.5)
-    connection_pool (2.5.5)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     crass (1.0.6)
-    date (3.5.0)
+    date (3.5.1)
     docile (1.4.1)
     drb (2.2.3)
-    erb (6.0.0)
+    erb (6.0.1)
     erubi (1.13.1)
     globalid (1.3.0)
       activesupport (>= 6.1)
     has_scope (0.9.0)
       actionpack (>= 7.0)
       activesupport (>= 7.0)
-    i18n (1.14.7)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    io-console (0.8.1)
-    irb (1.15.3)
+    io-console (0.8.2)
+    irb (1.16.0)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.16.0)
+    json (2.18.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.24.1)
+    loofah (2.25.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -125,7 +125,8 @@ GEM
     marcel (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.26.2)
+    minitest (6.0.1)
+      prism (~> 1.5)
     minitest-reporters (1.7.1)
       ansi
       builder
@@ -133,7 +134,7 @@ GEM
       ruby-progressbar
     mocha (2.8.2)
       ruby2_keywords (>= 0.0.5)
-    net-imap (0.5.12)
+    net-imap (0.6.2)
       date
       net-protocol
     net-pop (0.1.2)
@@ -161,8 +162,8 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.6.0)
-    psych (5.2.6)
+    prism (1.7.0)
+    psych (5.3.1)
       date
       stringio
     racc (1.8.1)
@@ -172,7 +173,7 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (2.2.1)
+    rackup (2.3.1)
       rack (>= 3)
     rails (8.1.1)
       actioncable (= 8.1.1)
@@ -210,7 +211,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.1)
-    rdoc (6.16.1)
+    rdoc (7.0.3)
       erb
       psych (>= 4.0.0)
       tsort
@@ -221,7 +222,7 @@ GEM
       actionpack (>= 7.0)
       railties (>= 7.0)
     rexml (3.4.4)
-    rubocop (1.81.7)
+    rubocop (1.82.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -229,12 +230,12 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.47.1, < 2.0)
+      rubocop-ast (>= 1.48.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.48.0)
+    rubocop-ast (1.49.0)
       parser (>= 3.3.7.2)
-      prism (~> 1.4)
+      prism (~> 1.7)
     rubocop-minitest (0.38.2)
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
@@ -258,15 +259,15 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    stringio (3.1.8)
+    stringio (3.2.0)
     thor (1.4.0)
-    timeout (0.4.4)
+    timeout (0.6.0)
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
-    unicode-emoji (4.1.0)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
     warning (1.5.0)
@@ -274,7 +275,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.7.3)
+    zeitwerk (2.7.4)
 
 PLATFORMS
   aarch64-linux
@@ -287,7 +288,7 @@ DEPENDENCIES
   inherited_resources!
   minitest
   minitest-reporters
-  mocha
+  mocha (~> 2.8)
   rails (~> 8.1.0)
   rails-controller-testing
   rubocop
@@ -299,4 +300,4 @@ DEPENDENCIES
   warning
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/rails_70/Gemfile
+++ b/gemfiles/rails_70/Gemfile
@@ -6,7 +6,7 @@ gemspec path: '../..'
 group :development do
   gem 'rails', '~> 7.0.0'
 
-  gem 'mocha'
+  gem 'mocha', '~> 2.8' # TODO: relax this dependency after fixing #981
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'rails-controller-testing'

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -86,11 +86,11 @@ GEM
     ansi (1.5.0)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (3.3.1)
+    bigdecimal (4.0.1)
     builder (3.3.0)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.6)
     crass (1.0.6)
-    date (3.5.0)
+    date (3.5.1)
     docile (1.4.1)
     drb (2.2.3)
     erubi (1.13.1)
@@ -99,10 +99,10 @@ GEM
     has_scope (0.9.0)
       actionpack (>= 7.0)
       activesupport (>= 7.0)
-    i18n (1.14.7)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     logger (1.7.0)
-    loofah (2.24.1)
+    loofah (2.25.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -115,7 +115,7 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.26.2)
+    minitest (5.27.0)
     minitest-reporters (1.7.1)
       ansi
       builder
@@ -124,7 +124,7 @@ GEM
     mocha (2.8.2)
       ruby2_keywords (>= 0.0.5)
     mutex_m (0.3.0)
-    net-imap (0.5.12)
+    net-imap (0.5.13)
       date
       net-protocol
     net-pop (0.1.2)
@@ -199,7 +199,7 @@ GEM
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     thor (1.4.0)
-    timeout (0.4.4)
+    timeout (0.6.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     warning (1.5.0)
@@ -220,7 +220,7 @@ DEPENDENCIES
   inherited_resources!
   minitest
   minitest-reporters
-  mocha
+  mocha (~> 2.8)
   rails (~> 7.0.0)
   rails-controller-testing
   simplecov
@@ -229,4 +229,4 @@ DEPENDENCIES
   zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.7.2
+   2.6.9

--- a/gemfiles/rails_71/Gemfile
+++ b/gemfiles/rails_71/Gemfile
@@ -6,7 +6,7 @@ gemspec path: '../..'
 group :development do
   gem 'rails', '~> 7.1.0'
 
-  gem 'mocha'
+  gem 'mocha', '~> 2.8' # TODO: relax this dependency after fixing #981
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'rails-controller-testing'

--- a/gemfiles/rails_71/Gemfile.lock
+++ b/gemfiles/rails_71/Gemfile.lock
@@ -92,13 +92,13 @@ GEM
     ansi (1.5.0)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (3.3.1)
+    bigdecimal (4.0.1)
     builder (3.3.0)
-    cgi (0.5.0)
-    concurrent-ruby (1.3.5)
+    cgi (0.5.1)
+    concurrent-ruby (1.3.6)
     connection_pool (2.5.5)
     crass (1.0.6)
-    date (3.5.0)
+    date (3.5.1)
     docile (1.4.1)
     drb (2.2.3)
     erb (4.0.4)
@@ -109,15 +109,15 @@ GEM
     has_scope (0.9.0)
       actionpack (>= 7.0)
       activesupport (>= 7.0)
-    i18n (1.14.7)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    io-console (0.8.1)
-    irb (1.15.3)
+    io-console (0.8.2)
+    irb (1.16.0)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     logger (1.7.0)
-    loofah (2.24.1)
+    loofah (2.25.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -129,7 +129,7 @@ GEM
     marcel (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.26.2)
+    minitest (5.27.0)
     minitest-reporters (1.7.1)
       ansi
       builder
@@ -138,7 +138,7 @@ GEM
     mocha (2.8.2)
       ruby2_keywords (>= 0.0.5)
     mutex_m (0.3.0)
-    net-imap (0.5.12)
+    net-imap (0.5.13)
       date
       net-protocol
     net-pop (0.1.2)
@@ -162,7 +162,7 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    psych (5.2.6)
+    psych (5.3.1)
       date
       stringio
     racc (1.8.1)
@@ -172,7 +172,7 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (2.2.1)
+    rackup (2.3.1)
       rack (>= 3)
     rails (7.1.6)
       actioncable (= 7.1.6)
@@ -210,7 +210,7 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rake (13.3.1)
-    rdoc (6.16.1)
+    rdoc (7.0.3)
       erb
       psych (>= 4.0.0)
       tsort
@@ -232,9 +232,9 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    stringio (3.1.8)
+    stringio (3.2.0)
     thor (1.4.0)
-    timeout (0.4.4)
+    timeout (0.6.0)
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -257,7 +257,7 @@ DEPENDENCIES
   inherited_resources!
   minitest
   minitest-reporters
-  mocha
+  mocha (~> 2.8)
   rails (~> 7.1.0)
   rails-controller-testing
   simplecov
@@ -266,4 +266,4 @@ DEPENDENCIES
   zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.7.2
+   2.6.9

--- a/gemfiles/rails_72/Gemfile
+++ b/gemfiles/rails_72/Gemfile
@@ -6,7 +6,7 @@ gemspec path: '../..'
 group :development do
   gem 'rails', '~> 7.2.0'
 
-  gem 'mocha'
+  gem 'mocha', '~> 2.8' # TODO: relax this dependency after fixing #981
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'rails-controller-testing'

--- a/gemfiles/rails_72/Gemfile.lock
+++ b/gemfiles/rails_72/Gemfile.lock
@@ -86,13 +86,13 @@ GEM
     ansi (1.5.0)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (3.3.1)
+    bigdecimal (4.0.1)
     builder (3.3.0)
-    cgi (0.5.0)
-    concurrent-ruby (1.3.5)
+    cgi (0.5.1)
+    concurrent-ruby (1.3.6)
     connection_pool (2.5.5)
     crass (1.0.6)
-    date (3.5.0)
+    date (3.5.1)
     docile (1.4.1)
     drb (2.2.3)
     erb (4.0.4)
@@ -103,15 +103,15 @@ GEM
     has_scope (0.9.0)
       actionpack (>= 7.0)
       activesupport (>= 7.0)
-    i18n (1.14.7)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    io-console (0.8.1)
-    irb (1.15.3)
+    io-console (0.8.2)
+    irb (1.16.0)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     logger (1.7.0)
-    loofah (2.24.1)
+    loofah (2.25.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -123,7 +123,7 @@ GEM
     marcel (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.26.2)
+    minitest (5.27.0)
     minitest-reporters (1.7.1)
       ansi
       builder
@@ -131,7 +131,7 @@ GEM
       ruby-progressbar
     mocha (2.8.2)
       ruby2_keywords (>= 0.0.5)
-    net-imap (0.5.12)
+    net-imap (0.5.13)
       date
       net-protocol
     net-pop (0.1.2)
@@ -155,7 +155,7 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    psych (5.2.6)
+    psych (5.3.1)
       date
       stringio
     racc (1.8.1)
@@ -165,7 +165,7 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (2.2.1)
+    rackup (2.3.1)
       rack (>= 3)
     rails (7.2.3)
       actioncable (= 7.2.3)
@@ -203,7 +203,7 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rake (13.3.1)
-    rdoc (6.16.1)
+    rdoc (7.0.3)
       erb
       psych (>= 4.0.0)
       tsort
@@ -225,9 +225,9 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    stringio (3.1.8)
+    stringio (3.2.0)
     thor (1.4.0)
-    timeout (0.4.4)
+    timeout (0.6.0)
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -251,7 +251,7 @@ DEPENDENCIES
   inherited_resources!
   minitest
   minitest-reporters
-  mocha
+  mocha (~> 2.8)
   rails (~> 7.2.0)
   rails-controller-testing
   simplecov
@@ -260,4 +260,4 @@ DEPENDENCIES
   zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.7.2
+   2.6.9

--- a/gemfiles/rails_80/Gemfile
+++ b/gemfiles/rails_80/Gemfile
@@ -6,7 +6,7 @@ gemspec path: '../..'
 group :development do
   gem 'rails', '~> 8.0.0'
 
-  gem 'mocha'
+  gem 'mocha', '~> 2.8' # TODO: relax this dependency after fixing #981
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'rails-controller-testing'

--- a/gemfiles/rails_80/Gemfile.lock
+++ b/gemfiles/rails_80/Gemfile.lock
@@ -84,30 +84,30 @@ GEM
     ansi (1.5.0)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (3.3.1)
+    bigdecimal (4.0.1)
     builder (3.3.0)
-    concurrent-ruby (1.3.5)
-    connection_pool (2.5.5)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     crass (1.0.6)
-    date (3.5.0)
+    date (3.5.1)
     docile (1.4.1)
     drb (2.2.3)
-    erb (6.0.0)
+    erb (6.0.1)
     erubi (1.13.1)
     globalid (1.3.0)
       activesupport (>= 6.1)
     has_scope (0.9.0)
       actionpack (>= 7.0)
       activesupport (>= 7.0)
-    i18n (1.14.7)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    io-console (0.8.1)
-    irb (1.15.3)
+    io-console (0.8.2)
+    irb (1.16.0)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     logger (1.7.0)
-    loofah (2.24.1)
+    loofah (2.25.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -119,7 +119,8 @@ GEM
     marcel (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.26.2)
+    minitest (6.0.1)
+      prism (~> 1.5)
     minitest-reporters (1.7.1)
       ansi
       builder
@@ -127,7 +128,7 @@ GEM
       ruby-progressbar
     mocha (2.8.2)
       ruby2_keywords (>= 0.0.5)
-    net-imap (0.5.12)
+    net-imap (0.6.2)
       date
       net-protocol
     net-pop (0.1.2)
@@ -151,7 +152,8 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    psych (5.2.6)
+    prism (1.7.0)
+    psych (5.3.1)
       date
       stringio
     racc (1.8.1)
@@ -161,7 +163,7 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (2.2.1)
+    rackup (2.3.1)
       rack (>= 3)
     rails (8.0.4)
       actioncable (= 8.0.4)
@@ -198,7 +200,7 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rake (13.3.1)
-    rdoc (6.16.1)
+    rdoc (7.0.3)
       erb
       psych (>= 4.0.0)
       tsort
@@ -220,9 +222,9 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    stringio (3.1.8)
+    stringio (3.2.0)
     thor (1.4.0)
-    timeout (0.4.4)
+    timeout (0.6.0)
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -233,7 +235,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.7.3)
+    zeitwerk (2.7.4)
 
 PLATFORMS
   aarch64-linux
@@ -246,7 +248,7 @@ DEPENDENCIES
   inherited_resources!
   minitest
   minitest-reporters
-  mocha
+  mocha (~> 2.8)
   rails (~> 8.0.0)
   rails-controller-testing
   simplecov
@@ -254,4 +256,4 @@ DEPENDENCIES
   warning
 
 BUNDLED WITH
-   2.7.2
+  4.0.3


### PR DESCRIPTION
Additionally:
- Update dependencies by using the oldest supported Ruby version for
  each Gemfile
- Retest against Ruby 3.1. Since it is supported, it should be tested
  to avoid unintended breaking changes
- Lock Mocha to v2 because of https://github.com/activeadmin/inherited_resources/issues/981