### PR TITLE
Use hash literal for Mocha .with matcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec path: '.'
 group :development do
   gem 'rails', '~> 8.1.0'
 
-  gem 'mocha', '~> 2.8' # TODO: relax this dependency after fixing #981
+  gem 'mocha'
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mocha (2.8.2)
+    mocha (3.0.1)
       ruby2_keywords (>= 0.0.5)
     net-imap (0.6.2)
       date
@@ -288,7 +288,7 @@ DEPENDENCIES
   inherited_resources!
   minitest
   minitest-reporters
-  mocha (~> 2.8)
+  mocha
   rails (~> 8.1.0)
   rails-controller-testing
   rubocop

--- a/gemfiles/rails_70/Gemfile
+++ b/gemfiles/rails_70/Gemfile
@@ -6,7 +6,7 @@ gemspec path: '../..'
 group :development do
   gem 'rails', '~> 7.0.0'
 
-  gem 'mocha', '~> 2.8' # TODO: relax this dependency after fixing #981
+  gem 'mocha'
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'rails-controller-testing'

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mocha (2.8.2)
+    mocha (3.0.1)
       ruby2_keywords (>= 0.0.5)
     mutex_m (0.3.0)
     net-imap (0.5.13)
@@ -220,7 +220,7 @@ DEPENDENCIES
   inherited_resources!
   minitest
   minitest-reporters
-  mocha (~> 2.8)
+  mocha
   rails (~> 7.0.0)
   rails-controller-testing
   simplecov

--- a/gemfiles/rails_71/Gemfile
+++ b/gemfiles/rails_71/Gemfile
@@ -6,7 +6,7 @@ gemspec path: '../..'
 group :development do
   gem 'rails', '~> 7.1.0'
 
-  gem 'mocha', '~> 2.8' # TODO: relax this dependency after fixing #981
+  gem 'mocha'
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'rails-controller-testing'

--- a/gemfiles/rails_71/Gemfile.lock
+++ b/gemfiles/rails_71/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mocha (2.8.2)
+    mocha (3.0.1)
       ruby2_keywords (>= 0.0.5)
     mutex_m (0.3.0)
     net-imap (0.5.13)
@@ -257,7 +257,7 @@ DEPENDENCIES
   inherited_resources!
   minitest
   minitest-reporters
-  mocha (~> 2.8)
+  mocha
   rails (~> 7.1.0)
   rails-controller-testing
   simplecov

--- a/gemfiles/rails_72/Gemfile
+++ b/gemfiles/rails_72/Gemfile
@@ -6,7 +6,7 @@ gemspec path: '../..'
 group :development do
   gem 'rails', '~> 7.2.0'
 
-  gem 'mocha', '~> 2.8' # TODO: relax this dependency after fixing #981
+  gem 'mocha'
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'rails-controller-testing'

--- a/gemfiles/rails_72/Gemfile.lock
+++ b/gemfiles/rails_72/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mocha (2.8.2)
+    mocha (3.0.1)
       ruby2_keywords (>= 0.0.5)
     net-imap (0.5.13)
       date
@@ -251,7 +251,7 @@ DEPENDENCIES
   inherited_resources!
   minitest
   minitest-reporters
-  mocha (~> 2.8)
+  mocha
   rails (~> 7.2.0)
   rails-controller-testing
   simplecov

--- a/gemfiles/rails_80/Gemfile
+++ b/gemfiles/rails_80/Gemfile
@@ -6,7 +6,7 @@ gemspec path: '../..'
 group :development do
   gem 'rails', '~> 8.0.0'
 
-  gem 'mocha', '~> 2.8' # TODO: relax this dependency after fixing #981
+  gem 'mocha'
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'rails-controller-testing'

--- a/gemfiles/rails_80/Gemfile.lock
+++ b/gemfiles/rails_80/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mocha (2.8.2)
+    mocha (3.0.1)
       ruby2_keywords (>= 0.0.5)
     net-imap (0.6.2)
       date
@@ -248,7 +248,7 @@ DEPENDENCIES
   inherited_resources!
   minitest
   minitest-reporters
-  mocha (~> 2.8)
+  mocha
   rails (~> 8.0.0)
   rails-controller-testing
   simplecov

--- a/test/strong_parameters_test.rb
+++ b/test/strong_parameters_test.rb
@@ -29,19 +29,19 @@ class StrongParametersTest < ActionController::TestCase
   end
 
   def test_permitted_params_from_new # rubocop:disable Minitest/NoAssertions
-    Widget.expects(:new).with(permitted: 'param')
+    Widget.expects(:new).with({ permitted: 'param' })
     get :new, params: { widget: { permitted: 'param', prohibited: 'param' } }
   end
 
   def test_permitted_params_from_create # rubocop:disable Minitest/NoAssertions
-    Widget.expects(:new).with(permitted: 'param').returns(mock(save: true))
+    Widget.expects(:new).with({ permitted: 'param' }).returns(mock(save: true))
     post :create, params: { widget: { permitted: 'param', prohibited: 'param' } }
   end
 
   def test_permitted_params_from_update # rubocop:disable Minitest/NoAssertions
     mock_widget = mock
     mock_widget.stubs(:class).returns(Widget)
-    mock_widget.expects(:update).with(permitted: 'param')
+    mock_widget.expects(:update).with({ permitted: 'param' })
     mock_widget.stubs(:persisted?).returns(true)
     mock_widget.stubs(:to_model).returns(mock_widget)
     mock_widget.stubs(:model_name).returns(Widget.model_name)
@@ -55,7 +55,7 @@ class StrongParametersTest < ActionController::TestCase
     class << @controller
       private :widget_params
     end
-    Widget.expects(:new).with(permitted: 'param')
+    Widget.expects(:new).with({ permitted: 'param' })
     get :new, params: { widget: { permitted: 'param', prohibited: 'param' } }
   end
 end
@@ -80,19 +80,19 @@ class StrongParametersWithoutPermittedParamsTest < ActionController::TestCase
   end
 
   def test_permitted_params_from_new # rubocop:disable Minitest/NoAssertions
-    Widget.expects(:new).with(permitted: 'param')
+    Widget.expects(:new).with({ permitted: 'param' })
     get :new, params: { widget: { permitted: 'param', prohibited: 'param' } }
   end
 
   def test_permitted_params_from_create # rubocop:disable Minitest/NoAssertions
-    Widget.expects(:new).with(permitted: 'param').returns(mock(save: true))
+    Widget.expects(:new).with({ permitted: 'param' }).returns(mock(save: true))
     post :create, params: { widget: { permitted: 'param', prohibited: 'param' } }
   end
 
   def test_permitted_params_from_update # rubocop:disable Minitest/NoAssertions
     mock_widget = mock
     mock_widget.stubs(:class).returns(Widget)
-    mock_widget.expects(:update).with(permitted: 'param')
+    mock_widget.expects(:update).with({ permitted: 'param' })
     mock_widget.stubs(:persisted?).returns(true)
     mock_widget.stubs(:to_model).returns(mock_widget)
     mock_widget.stubs(:model_name).returns(Widget.model_name)

--- a/test/url_helpers_test.rb
+++ b/test/url_helpers_test.rb
@@ -185,7 +185,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
       controller.send(:"resource_#{path_or_url}", :arg)
 
       # With options
-      controller.expects("house_#{path_or_url}").with(:arg, page: 1).once
+      controller.expects("house_#{path_or_url}").with(:arg, { page: 1 }).once
       controller.send(:"resource_#{path_or_url}", :arg, page: 1)
     end
   end
@@ -215,7 +215,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
       controller.send(:"resource_#{path_or_url}", :arg)
 
       # With options
-      controller.expects("news_#{path_or_url}").with(:arg, page: 1).once
+      controller.expects("news_#{path_or_url}").with(:arg, { page: 1 }).once
       controller.send(:"resource_#{path_or_url}", :arg, page: 1)
     end
   end
@@ -247,7 +247,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
       controller.send(:"resource_#{path_or_url}", :arg)
 
       # With options
-      controller.expects("admin_backpack_#{path_or_url}").with(:arg, page: 1).once
+      controller.expects("admin_backpack_#{path_or_url}").with(:arg, { page: 1 }).once
       controller.send(:"resource_#{path_or_url}", :arg, page: 1)
     end
   end
@@ -271,7 +271,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
 
       # With options
       # Also tests that argument sent are not used
-      controller.expects("universum_#{path_or_url}").with(page: 1).once
+      controller.expects("universum_#{path_or_url}").with({ page: 1 }).once
       controller.send(:"resource_#{path_or_url}", :arg, page: 1)
     end
   end
@@ -303,7 +303,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
 
       # With options
       # Also tests that argument sent are not used
-      controller.expects("house_fireplace_flame_#{path_or_url}").with(:house, :arg, page: 1).once
+      controller.expects("house_fireplace_flame_#{path_or_url}").with(:house, :arg, { page: 1 }).once
       controller.send(:"resource_#{path_or_url}", :arg, page: 1)
     end
   end
@@ -343,7 +343,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
       controller.send(:"parent_#{path_or_url}", :arg)
 
       # With options
-      controller.expects("house_table_#{path_or_url}").with(:house, :arg, page: 1).once
+      controller.expects("house_table_#{path_or_url}").with(:house, :arg, { page: 1 }).once
       controller.send(:"resource_#{path_or_url}", :arg, page: 1)
     end
   end
@@ -383,7 +383,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
       controller.send(:"parent_#{path_or_url}", :arg)
 
       # With options
-      controller.expects("big_house_room_#{path_or_url}").with(:house, :arg, page: 1).once
+      controller.expects("big_house_room_#{path_or_url}").with(:house, :arg, { page: 1 }).once
       controller.send(:"resource_#{path_or_url}", :arg, page: 1)
     end
   end
@@ -424,7 +424,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
       controller.send(:"parent_#{path_or_url}", :arg)
 
       # With options
-      controller.expects("edit_house_table_chair_#{path_or_url}").with(:house, :table, :arg, page: 1).once
+      controller.expects("edit_house_table_chair_#{path_or_url}").with(:house, :table, :arg, { page: 1 }).once
       controller.send(:"edit_resource_#{path_or_url}", :arg, page: 1)
     end
   end
@@ -455,7 +455,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
 
       # With options
       # Also tests that argument sent are not used
-      controller.expects("house_owner_#{path_or_url}").with(:house, page: 1).once
+      controller.expects("house_owner_#{path_or_url}").with(:house, { page: 1 }).once
       controller.send(:"resource_#{path_or_url}", :arg, page: 1)
     end
   end
@@ -536,10 +536,10 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
 
     # With options
-    mock_polymorphic(controller, "house_bed_url").with(house, bed, page: 1).once
+    mock_polymorphic(controller, "house_bed_url").with(house, bed, { page: 1 }).once
     controller.send(:resource_url, page: 1)
 
-    mock_polymorphic(controller, "house_url").with(house, page: 1).once
+    mock_polymorphic(controller, "house_url").with(house, { page: 1 }).once
     controller.send(:parent_url, page: 1)
 
     # With args
@@ -592,10 +592,10 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
 
     # With options
-    mock_polymorphic(controller, "news_sheep_url").with(news, sheep, page: 1).once
+    mock_polymorphic(controller, "news_sheep_url").with(news, sheep, { page: 1 }).once
     controller.send(:resource_url, page: 1)
 
-    mock_polymorphic(controller, "news_url").with(news, page: 1).once
+    mock_polymorphic(controller, "news_url").with(news, { page: 1 }).once
     controller.send(:parent_url, page: 1)
 
     # With args
@@ -681,10 +681,10 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
 
     # With options
-    mock_polymorphic(controller, "admin_house_desk_url").with(house, desk, page: 1).once
+    mock_polymorphic(controller, "admin_house_desk_url").with(house, desk, { page: 1 }).once
     controller.send(:resource_url, page: 1)
 
-    mock_polymorphic(controller, "admin_house_url").with(house, page: 1).once
+    mock_polymorphic(controller, "admin_house_url").with(house, { page: 1 }).once
     controller.send(:parent_url, page: 1)
 
     # With args
@@ -739,10 +739,10 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
 
     # With options
-    mock_polymorphic(controller, "house_table_dish_url").with(house, table, dish, page: 1).once
+    mock_polymorphic(controller, "house_table_dish_url").with(house, table, dish, { page: 1 }).once
     controller.send(:resource_url, page: 1)
 
-    mock_polymorphic(controller, "house_table_url").with(house, table, page: 1).once
+    mock_polymorphic(controller, "house_table_url").with(house, table, { page: 1 }).once
     controller.send(:parent_url, page: 1)
 
     # With args
@@ -793,10 +793,10 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
 
     # With options
-    mock_polymorphic(controller, "house_table_center_url").with(house, table, page: 1)
+    mock_polymorphic(controller, "house_table_center_url").with(house, table, { page: 1 }).once
     controller.send(:resource_url, page: 1)
 
-    mock_polymorphic(controller, "house_table_url").with(house, table, page: 1)
+    mock_polymorphic(controller, "house_table_url").with(house, table, { page: 1 }).once
     controller.send(:parent_url, page: 1)
 
     # With args
@@ -833,7 +833,7 @@ class UrlHelpersTest < ActiveSupport::TestCase
     end
 
     # With options
-    mock_polymorphic(controller, "bed_url").with(bed, page: 1).once
+    mock_polymorphic(controller, "bed_url").with(bed, { page: 1 }).once
     controller.send(:resource_url, page: 1)
 
     # With args


### PR DESCRIPTION
Mocha commit https://github.com/freerange/mocha/commit/38553330 changed argument matching
behavior: `.with` no longer normalizes or coerces hash options.

The `.with` matcher now requires that arguments match exactly,
including type. This means a hash must be an explicit hash
literal, not just keyword arguments.

Update tests to pass options as a hash literal, e.g.
`with({ permitted: param })` instead of `with(permitted: param)`.

Close https://github.com/activeadmin/inherited_resources/issues/981