### PR TITLE
Prevent Dependabot PRs for Minitest 6.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,8 @@ updates:
         patterns:
           - "*"
     ignore:
+      - dependency-name: minitest
+        versions: ">= 6.0.0"
       - dependency-name: rails
         versions: ">= 7.1.0"
       - dependency-name: railties
@@ -43,6 +45,8 @@ updates:
     ignore:
       - dependency-name: erb
         versions: ">= 5"
+      - dependency-name: minitest
+        versions: ">= 6.0.0"
       - dependency-name: rails
         versions: ">= 7.2.0"
       - dependency-name: railties
@@ -59,6 +63,8 @@ updates:
     ignore:
       - dependency-name: erb
         versions: ">= 5"
+      - dependency-name: minitest
+        versions: ">= 6.0.0"
       - dependency-name: rails
         versions: ">= 8.0.0"
       - dependency-name: railties


### PR DESCRIPTION
Update configuration to avoid Minitest 6.x updates on Rails 7.x gemfiles, which are still tested with Ruby 3.1.

This prevents Dependabot from opening PRs incompatible with the supported Ruby versions, as happened with #983, #984, and #985.